### PR TITLE
lzc_receive: add a possibility to take the snapshot name from the stream

### DIFF
--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -133,13 +133,6 @@ zfs_callback(zfs_handle_t *zhp, void *data)
 	    ((cb->cb_flags & ZFS_ITER_DEPTH_LIMIT) == 0 ||
 	    cb->cb_depth < cb->cb_depth_limit)) {
 		cb->cb_depth++;
-		if (zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM)
-			(void) zfs_iter_filesystems(zhp, zfs_callback, data);
-		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
-		    ZFS_TYPE_BOOKMARK)) == 0) && include_snaps)
-			(void) zfs_iter_snapshots(zhp,
-			    (cb->cb_flags & ZFS_ITER_SIMPLE) != 0, zfs_callback,
-			    data);
 		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
 		    ZFS_TYPE_BOOKMARK)) == 0) && include_bmarks)
 			(void) zfs_iter_bookmarks(zhp, zfs_callback, data);
@@ -391,7 +384,7 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 	 * XXX: We are phasing out the legacy recursive interface in
 	 * favor of the new stable list API.
 	 */
-	cb.cb_flags = flags & ~ZFS_ITER_RECURSE;
+	cb.cb_flags = flags;
 	cb.cb_proplist = proplist;
 	cb.cb_types = types;
 	cb.cb_depth_limit = limit;
@@ -471,8 +464,9 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 			if (zhp != NULL)
 				ret |= zfs_iter_generic(zfs_get_handle(zhp),
 				    zfs_get_name(zhp), argtype, (flags &
-				    ZFS_ITER_DEPTH_LIMIT) ? limit : 0,
-				    zfs_callback, &cb);
+				    ZFS_ITER_DEPTH_LIMIT) ? limit : (flags &
+				    ZFS_ITER_RECURSE) ? -1 : 0, zfs_callback,
+				    &cb);
 			else
 				ret = 1;
 		}

--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -378,6 +378,7 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 	int ret = 0;
 	zfs_node_t *node;
 	uu_avl_walk_t *walk;
+	zfs_type_t argtype;
 
 	avl_pool = uu_avl_pool_create("zfs_pool", sizeof (zfs_node_t),
 	    offsetof(zfs_node_t, zn_avlnode), zfs_sort, UU_DEFAULT);
@@ -386,7 +387,11 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 		nomem();
 
 	cb.cb_sortcol = sortcol;
-	cb.cb_flags = flags;
+	/*
+	 * XXX: We are phasing out the legacy recursive interface in
+	 * favor of the new stable list API.
+	 */
+	cb.cb_flags = flags & ~ZFS_ITER_RECURSE;
 	cb.cb_proplist = proplist;
 	cb.cb_types = types;
 	cb.cb_depth_limit = limit;
@@ -431,27 +436,29 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 	if ((cb.cb_avl = uu_avl_create(avl_pool, NULL, UU_DEFAULT)) == NULL)
 		nomem();
 
+	/*
+	 * zfs_iter_generic() lets the kernel worry about default types.
+	 */
+	argtype = types * !!(flags & ZFS_ITER_TYPES_SPECIFIED);
 	if (argc == 0) {
 		/*
 		 * If given no arguments, iterate over all datasets.
 		 */
-		cb.cb_flags |= ZFS_ITER_RECURSE;
-		ret = zfs_iter_root(g_zfs, zfs_callback, &cb);
+		ret = zfs_iter_generic(g_zfs, NULL, argtype, (flags &
+		    ZFS_ITER_DEPTH_LIMIT) ? limit : -1, zfs_callback, &cb);
 	} else {
 		int i;
 		zfs_handle_t *zhp;
-		zfs_type_t argtype;
 
 		/*
 		 * If we're recursive, then we always allow filesystems as
 		 * arguments.  If we also are interested in snapshots, then we
 		 * can take volumes as well.
 		 */
-		argtype = types;
 		if (flags & ZFS_ITER_RECURSE) {
 			argtype |= ZFS_TYPE_FILESYSTEM;
 			if (types & ZFS_TYPE_SNAPSHOT)
-				argtype |= ZFS_TYPE_VOLUME;
+				argtype |= ZFS_TYPE_VOLUME | ZFS_TYPE_SNAPSHOT;
 		}
 
 		for (i = 0; i < argc; i++) {
@@ -462,7 +469,10 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 				zhp = zfs_open(g_zfs, argv[i], argtype);
 			}
 			if (zhp != NULL)
-				ret |= zfs_callback(zhp, &cb);
+				ret |= zfs_iter_generic(zfs_get_handle(zhp),
+				    zfs_get_name(zhp), argtype, (flags &
+				    ZFS_ITER_DEPTH_LIMIT) ? limit : 0,
+				    zfs_callback, &cb);
 			else
 				ret = 1;
 		}

--- a/cmd/zfs/zfs_iter.h
+++ b/cmd/zfs/zfs_iter.h
@@ -47,6 +47,7 @@ typedef struct zfs_sort_column {
 #define	ZFS_ITER_RECVD_PROPS	   (1 << 4)
 #define	ZFS_ITER_LITERAL_PROPS	   (1 << 5)
 #define	ZFS_ITER_SIMPLE		   (1 << 6)
+#define	ZFS_ITER_TYPES_SPECIFIED   (1 << 7)
 
 int zfs_for_each(int, char **, int options, zfs_type_t,
     zfs_sort_column_t *, zprop_list_t **, int, zfs_iter_f, void *);

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1714,7 +1714,7 @@ zfs_do_get(int argc, char **argv)
 
 		case 't':
 			types = 0;
-			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
+			flags |= ZFS_ITER_TYPES_SPECIFIED;
 			while (*optarg != '\0') {
 				static char *type_subopts[] = { "filesystem",
 				    "volume", "snapshot", "bookmark",
@@ -3034,14 +3034,13 @@ zfs_do_list(int argc, char **argv)
 	static char default_fields[] =
 	    "name,used,available,referenced,mountpoint";
 	int types = ZFS_TYPE_DATASET;
-	boolean_t types_specified = B_FALSE;
 	char *fields = NULL;
 	list_cbdata_t cb = { 0 };
 	char *value;
 	int limit = 0;
 	int ret = 0;
 	zfs_sort_column_t *sortcol = NULL;
-	int flags = ZFS_ITER_PROP_LISTSNAPS | ZFS_ITER_ARGS_CAN_BE_PATHS;
+	int flags = ZFS_ITER_ARGS_CAN_BE_PATHS;
 
 	/* check options */
 	while ((c = getopt(argc, argv, "HS:d:o:prs:t:")) != -1) {
@@ -3080,8 +3079,7 @@ zfs_do_list(int argc, char **argv)
 			break;
 		case 't':
 			types = 0;
-			types_specified = B_TRUE;
-			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
+			flags |= ZFS_ITER_TYPES_SPECIFIED;
 			while (*optarg != '\0') {
 				static char *type_subopts[] = { "filesystem",
 				    "volume", "snapshot", "snap", "bookmark",
@@ -3142,7 +3140,7 @@ zfs_do_list(int argc, char **argv)
 	/*
 	 * If "-o space" and no types were specified, don't display snapshots.
 	 */
-	if (strcmp(fields, "space") == 0 && types_specified == B_FALSE)
+	if (strcmp(fields, "space") == 0 && (flags & ZFS_ITER_TYPES_SPECIFIED))
 		types &= ~ZFS_TYPE_SNAPSHOT;
 
 	/*

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,7 @@ AC_CONFIG_FILES([
 	etc/modules-load.d/Makefile
 	man/Makefile
 	man/man1/Makefile
+	man/man3/Makefile
 	man/man5/Makefile
 	man/man8/Makefile
 	lib/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -553,6 +553,8 @@ void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
  * Iterator functions.
  */
 typedef int (*zfs_iter_f)(zfs_handle_t *, void *);
+extern int zfs_iter_generic(libzfs_handle_t *, const char *, zfs_type_t,
+    int64_t, zfs_iter_f, void *);
 extern int zfs_iter_root(libzfs_handle_t *, zfs_iter_f, void *);
 extern int zfs_iter_children(zfs_handle_t *, zfs_iter_f, void *);
 extern int zfs_iter_dependents(zfs_handle_t *, boolean_t, zfs_iter_f, void *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -38,6 +38,7 @@ extern "C" {
 int libzfs_core_init(void);
 void libzfs_core_fini(void);
 
+int lzc_list (const char *, int, nvlist_t *);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -55,6 +55,9 @@ int lzc_hold(nvlist_t *, int, nvlist_t **);
 int lzc_release(nvlist_t *, nvlist_t **);
 int lzc_get_holds(const char *, nvlist_t **);
 
+int lzc_rename(const char *oldname, const char *newname, nvlist_t *opts,
+    char **errname);
+
 enum lzc_send_flags {
 	LZC_SEND_FLAG_EMBED_DATA = 1 << 0
 };

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -41,6 +41,7 @@ void libzfs_core_fini(void);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
+int lzc_promote(const char *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -57,6 +57,7 @@ enum lzc_send_flags {
 };
 
 int lzc_send(const char *, const char *, int, enum lzc_send_flags);
+int lzc_send_ext(const char *, const char *, int, nvlist_t *);
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_send_space(const char *, const char *, uint64_t *);
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -55,6 +55,7 @@ int lzc_hold(nvlist_t *, int, nvlist_t **);
 int lzc_release(nvlist_t *, nvlist_t **);
 int lzc_get_holds(const char *, nvlist_t **);
 
+int lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts);
 int lzc_rename(const char *oldname, const char *newname, nvlist_t *opts,
     char **errname);
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -61,6 +61,7 @@ int lzc_send(const char *, const char *, int, enum lzc_send_flags);
 int lzc_send_ext(const char *, const char *, int, nvlist_t *);
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_send_space(const char *, const char *, uint64_t *);
+int lzc_send_progress(const char *, int, uint64_t *);
 
 boolean_t lzc_exists(const char *);
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -42,6 +42,7 @@ int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *, nvlist_t *);
+int lzc_set_props(const char *, nvlist_t *, boolean_t);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -42,7 +42,7 @@ int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *, nvlist_t *);
-int lzc_set_props(const char *, nvlist_t *, boolean_t);
+int lzc_set_props(const char *, nvlist_t *, nvlist_t *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -41,7 +41,7 @@ void libzfs_core_fini(void);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
-int lzc_promote(const char *);
+int lzc_promote(const char *, nvlist_t *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -44,6 +44,7 @@ int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *, nvlist_t *);
 int lzc_set_props(const char *, nvlist_t *, nvlist_t *);
+int lzc_destroy_one(const char *, nvlist_t *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -38,7 +38,7 @@ extern "C" {
 int libzfs_core_init(void);
 void libzfs_core_fini(void);
 
-int lzc_list (const char *, int, nvlist_t *);
+int lzc_list (const char *, nvlist_t *);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -43,7 +43,7 @@ int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *, nvlist_t *);
-int lzc_set_props(const char *, nvlist_t *, nvlist_t *);
+int lzc_set_props(const char *, nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_destroy_one(const char *, nvlist_t *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -275,8 +275,8 @@ int dsl_destroy_snapshots_nvl(struct nvlist *snaps, boolean_t defer,
     struct nvlist *errlist);
 int dmu_objset_snapshot_one(const char *fsname, const char *snapname);
 int dmu_objset_snapshot_tmp(const char *, const char *, int);
-int dmu_objset_find(char *name, int func(const char *, void *), void *arg,
-    int flags);
+int dmu_objset_find(const char *name, int func(const char *, void *),
+    void *arg, int flags);
 void dmu_objset_byteswap(void *buf, size_t size);
 int dsl_dataset_rename_snapshot(const char *fsname,
     const char *oldsnapname, const char *newsnapname, boolean_t recursive);

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -120,6 +120,12 @@ struct objset {
 	sa_os_t *os_sa;
 };
 
+typedef struct dmu_oslnode {
+	list_t dol_child;
+	list_node_t dol_sibling;
+	struct dsl_dataset *dol_ds;
+} dmu_oslnode_t;
+
 #define	DMU_META_OBJSET		0
 #define	DMU_META_DNODE_OBJECT	0
 #define	DMU_OBJECT_IS_SPECIAL(obj) ((int64_t)(obj) <= 0)
@@ -167,6 +173,15 @@ boolean_t dmu_objset_userused_enabled(objset_t *os);
 int dmu_objset_userspace_upgrade(objset_t *os);
 boolean_t dmu_objset_userspace_present(objset_t *os);
 int dmu_fsname(const char *snapname, char *buf);
+
+/* Code for handling userspace interface */
+extern const char *dmu_objset_types[];
+
+dmu_oslnode_t *
+dmu_oslnode_alloc(dmu_oslnode_t *parent, struct dsl_dataset *ds);
+int dmu_objset_getlist(struct dsl_pool *dp, uint64_t ddobj, int flags,
+    dmu_oslnode_t **grandparent, unsigned int depth);
+void dmu_objset_freelist(dmu_oslnode_t *parent);
 
 void dmu_objset_init(void);
 void dmu_objset_fini(void);

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -183,6 +183,10 @@ int dmu_objset_getlist(struct dsl_pool *dp, uint64_t ddobj, int flags,
     dmu_oslnode_t **grandparent, unsigned int depth);
 void dmu_objset_freelist(dmu_oslnode_t *parent);
 
+const char *dmu_objset_type_name(dmu_objset_type_t type);
+nvlist_t *dmu_objset_stats_nvlist(dmu_objset_stats_t *stat);
+int dmu_objset_stat_nvlts (nvlist_t *nvl, dmu_objset_stats_t *stat);
+
 void dmu_objset_init(void);
 void dmu_objset_fini(void);
 

--- a/include/sys/dmu_send.h
+++ b/include/sys/dmu_send.h
@@ -38,7 +38,7 @@ struct drr_begin;
 struct avl_tree;
 
 int dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
-    int outfd, struct vnode *vp, offset_t *off);
+    boolean_t fromorigin, int outfd, struct vnode *vp, offset_t *off);
 int dmu_send_estimate(struct dsl_dataset *ds, struct dsl_dataset *fromds,
     uint64_t *sizep);
 int dmu_send_obj(const char *pool, uint64_t tosnap, uint64_t fromsnap,

--- a/include/sys/dsl_prop.h
+++ b/include/sys/dsl_prop.h
@@ -66,6 +66,7 @@ int dsl_prop_get(const char *ddname, const char *propname,
 int dsl_prop_get_integer(const char *ddname, const char *propname,
     uint64_t *valuep, char *setpoint);
 int dsl_prop_get_all(objset_t *os, nvlist_t **nvp);
+int dsl_prop_get_all_new(objset_t *os, nvlist_t **nvp);
 int dsl_prop_get_received(const char *dsname, nvlist_t **nvp);
 int dsl_prop_get_ds(struct dsl_dataset *ds, const char *propname,
     int intsz, int numints, void *buf, char *setpoint);

--- a/include/sys/dsl_prop.h
+++ b/include/sys/dsl_prop.h
@@ -54,6 +54,12 @@ typedef struct dsl_props_arg {
 	zprop_source_t pa_source;
 } dsl_props_arg_t;
 
+typedef struct dsl_props_sync_info {
+	const char *dpsi_dsname;
+	zprop_source_t dpsi_source;
+	uint64_t dpsi_val;
+} dsl_props_set_info_t;
+
 int dsl_prop_register(struct dsl_dataset *ds, const char *propname,
     dsl_prop_changed_cb_t *callback, void *cbarg);
 int dsl_prop_unregister(struct dsl_dataset *ds, const char *propname,

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -893,6 +893,11 @@ typedef enum zfs_ioc {
 	 */
 	ZFS_IOC_FREEBSD = ('Z' << 8) + 0xC0,
 
+	/*
+	 * OpenZFS - 1/64 numbers reserved.
+	 */
+	ZFS_IOC_OPENZFS = ('Z' << 8) + 0x100,
+	ZFS_IOC_LIBZFS_CORE,
 	ZFS_IOC_LAST
 } zfs_ioc_t;
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -32,6 +32,7 @@
 #define	_SYS_FS_ZFS_H
 
 #include <sys/time.h>
+#include <sys/list.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -262,6 +263,16 @@ int zfs_prop_index_to_string(zfs_prop_t, uint64_t, const char **);
 int zfs_prop_string_to_index(zfs_prop_t, const char *, uint64_t *);
 uint64_t zfs_prop_random_value(zfs_prop_t, uint64_t seed);
 boolean_t zfs_prop_valid_for_type(int, zfs_type_t, boolean_t);
+
+struct dmu_tx;
+typedef struct dmu_tx dmu_tx_t;
+typedef void (*zprop_special_cb_f)(void *, dmu_tx_t *);
+
+typedef struct {
+	void *psc_data;			/* Caller data */
+	zprop_special_cb_f *psc_cb;	/* Callback function */
+	list_node_t psc_link;		/* Structure to manage things */
+} zprop_special_info_t;
 
 /*
  * Pool property functions shared between libzfs and kernel.

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -354,6 +354,14 @@ typedef struct zfs_cmd {
 	zfs_stat_t	zc_stat;
 } zfs_cmd_t;
 
+typedef struct zfs_pipe_record {
+	uint32_t	zpr_data_size;		/* Payload size */
+	uint8_t		zpr_header_size;	/* Extension space after 8 bytes */
+	uint8_t		zpr_err;		/* Return code */
+	uint8_t		zpr_endian;		/* Endian bit: 0 is BE, 1 is LE */
+	uint8_t		zpr_reserved;		/* Reserved space */
+} zfs_pipe_record_t;
+
 typedef struct zfs_useracct {
 	char zu_domain[256];
 	uid_t zu_rid;

--- a/include/zfs_prop.h
+++ b/include/zfs_prop.h
@@ -61,6 +61,13 @@ typedef struct zfs_index {
 	uint64_t pi_value;
 } zprop_index_t;
 
+struct dmu_tx;
+typedef struct dmu_tx dmu_tx_t;
+
+typedef void (*zprop_special_cb_f)(void *, dmu_tx_t *);
+typedef int (*zprop_special_f)(zfs_prop_t, const void *, void **,
+    zprop_special_cb_f **);
+
 typedef struct {
 	const char *pd_name;		/* human-readable property name */
 	int pd_propnum;			/* property number */
@@ -78,6 +85,7 @@ typedef struct {
 	const zprop_index_t *pd_table;	/* for index properties, a table */
 					/* defining the possible values */
 	size_t pd_table_size;		/* number of entries in pd_table[] */
+	zprop_special_f *pd_special;	/* Special property callback */
 } zprop_desc_t;
 
 /*
@@ -87,6 +95,9 @@ void zfs_prop_init(void);
 zprop_type_t zfs_prop_get_type(zfs_prop_t);
 boolean_t zfs_prop_delegatable(zfs_prop_t prop);
 zprop_desc_t *zfs_prop_get_table(void);
+boolean_t zfs_prop_special(zfs_prop_t prop);
+int zfs_prop_call_special(zfs_prop_t prop, const void *data_in,
+    void **data_out, zprop_special_cb_f **);
 
 /*
  * zpool property functions
@@ -100,15 +111,15 @@ zprop_desc_t *zpool_prop_get_table(void);
  */
 void zprop_register_impl(int, const char *, zprop_type_t, uint64_t,
     const char *, zprop_attr_t, int, const char *, const char *,
-    boolean_t, boolean_t, const zprop_index_t *);
+    boolean_t, boolean_t, const zprop_index_t *, zprop_special_f *);
 void zprop_register_string(int, const char *, const char *,
-    zprop_attr_t attr, int, const char *, const char *);
+    zprop_attr_t attr, int, const char *, const char *, zprop_special_f *);
 void zprop_register_number(int, const char *, uint64_t, zprop_attr_t, int,
-    const char *, const char *);
+    const char *, const char *, zprop_special_f *);
 void zprop_register_index(int, const char *, uint64_t, zprop_attr_t, int,
-    const char *, const char *, const zprop_index_t *);
+    const char *, const char *, const zprop_index_t *, zprop_special_f *);
 void zprop_register_hidden(int, const char *, zprop_type_t, zprop_attr_t,
-    int, const char *);
+    int, const char *, zprop_special_f *);
 
 /*
  * Common routines for zfs and zpool property management

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -643,7 +643,10 @@ zfs_open(libzfs_handle_t *hdl, const char *path, int types)
 		return (NULL);
 	}
 
-	if (!(types & zhp->zfs_type)) {
+	/*
+	 * types == 0 is set when we have the kernel check the type for us.
+	 */
+	if (types && !(types & zhp->zfs_type)) {
 		(void) zfs_error(hdl, EZFS_BADTYPE, errbuf);
 		zfs_close(zhp);
 		return (NULL);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3774,7 +3774,7 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 	libzfs_handle_t *hdl = zhp->zfs_hdl;
 	char errbuf[1024];
 	char *errname;
-	nvlist_t *opts;
+	nvlist_t *opts = NULL;
 
 	/* if we have the same exact name, just return success */
 	if (strcmp(zhp->zfs_name, target) == 0)

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3238,7 +3238,8 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 int
 zfs_destroy(zfs_handle_t *zhp, boolean_t defer)
 {
-	zfs_cmd_t zc = {"\0"};
+	nvlist_t *opts = NULL;
+	int ret = 0;
 
 	if (zhp->zfs_type == ZFS_TYPE_BOOKMARK) {
 		nvlist_t *nv = fnvlist_alloc();
@@ -3253,17 +3254,16 @@ zfs_destroy(zfs_handle_t *zhp, boolean_t defer)
 		return (0);
 	}
 
-	(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
-
-	if (ZFS_IS_VOLUME(zhp)) {
-		zc.zc_objset_type = DMU_OST_ZVOL;
-	} else {
-		zc.zc_objset_type = DMU_OST_ZFS;
+	if (defer) {
+		opts = fnvlist_alloc();
+		fnvlist_add_boolean(opts, "defer");
 	}
 
-	zc.zc_defer_destroy = defer;
-	if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_DESTROY, &zc) != 0 &&
-	    errno != ENOENT) {
+	ret = lzc_destroy_one(zhp->zfs_name, opts);
+	if (defer)
+		fnvlist_free(opts);
+
+	if (ret != 0 && errno != ENOENT) {
 		return (zfs_standard_error_fmt(zhp->zfs_hdl, errno,
 		    dgettext(TEXT_DOMAIN, "cannot destroy '%s'"),
 		    zhp->zfs_name));

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -35,6 +35,12 @@
 
 #include "libzfs_impl.h"
 
+/*
+ * XXX: Workaround for conflicting type declarations for sa_handle_t between
+ * sys/sa.h and libshare.h
+ */
+extern int dmu_objset_stat_nvlts(nvlist_t *nvl, dmu_objset_stats_t *stat);
+
 int
 zfs_iter_clones(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
@@ -55,6 +61,170 @@ zfs_iter_clones(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 		}
 	}
 	return (0);
+}
+
+static char *zfs_types[] = { "filesystem", "snapshot", "volume", "pool",
+	"bookmark" };
+
+#define	ZFS_TYPE_COUNT	(sizeof (zfs_types) / sizeof (&zfs_types[0]))
+
+static nvlist_t *
+zfs_type_to_nvl(zfs_type_t type)
+{
+	nvlist_t *nvl = fnvlist_alloc();
+	int i;
+
+	for (i = 0; i < ZFS_TYPE_COUNT; i++)
+		if (type & (1 << i))
+			fnvlist_add_boolean(nvl, zfs_types[i]);
+
+	return (nvl);
+}
+
+/*
+ * Iterate over all children filesystems (stable)
+ */
+int
+zfs_iter_generic(libzfs_handle_t *hdl, const char *name, zfs_type_t type,
+    int64_t depth, zfs_iter_f func, void *data)
+{
+	zfs_cmd_t zc = {"\0"};
+	zfs_handle_t *nzhp;
+	nvlist_t *tnvl;
+	nvlist_t *opts;
+	int fildes[2];
+	zfs_pipe_record_t zpr;
+	int ret;
+
+	if (zcmd_alloc_dst_nvlist(hdl, &zc, 0) != 0)
+		return (-1);
+
+	ret = pipe(fildes);
+	if (ret == -1) {
+		switch (errno) {
+		default:
+			ret = zfs_standard_error(hdl, errno,
+			    dgettext(TEXT_DOMAIN,
+			    "cannot iterate filesystems"));
+			break;
+		}
+	}
+
+	opts = fnvlist_alloc();
+	switch (depth) {
+	case -1:
+		fnvlist_add_boolean(opts, "recurse");
+	case 0:
+		break;
+	default:
+		if (depth < 0) {
+			fnvlist_free(opts);
+			return (-1);
+		}
+		fnvlist_add_uint64(opts, "recurse", depth);
+	}
+
+	tnvl = zfs_type_to_nvl(type);
+	fnvlist_add_nvlist(opts, "type", tnvl);
+
+	if ((ret = lzc_list(name, fildes[1], opts)) != 0) {
+		fnvlist_free(opts);
+		close(fildes[0]);
+		close(fildes[1]);
+		return (ret);
+	}
+	fnvlist_free(tnvl);
+	fnvlist_free(opts);
+
+	while ((ret = read(fildes[0], &zpr,
+	    sizeof (zfs_pipe_record_t))) == sizeof (uint64_t) &&
+	    zpr.zpr_data_size != 0 && zpr.zpr_err == 0) {
+		nvlist_t *nvl, *nvl_prop, *nvl_dds;
+		char *name;
+#ifdef  _LITTLE_ENDIAN
+		uint32_t size = (zpr.zpr_endian) ? zpr.zpr_data_size :
+		    BSWAP_32(zpr.zpr_data_size);
+#else
+		uint32_t size = (zpr.zpr_endian) ? BSWAP_32(zpr.zpr_data_size) :
+		    zpr.zpr_data_size;
+#endif
+		char *buf = umem_alloc(size, UMEM_NOFAIL);
+
+		ret = read(fildes[0], buf, size);
+
+		if (size != ret || (ret = nvlist_unpack(buf +
+		    zpr.zpr_header_size, size, &nvl, 0)) != 0) {
+			umem_free(buf, size);
+			goto out;
+		}
+
+		if ((ret = nvlist_lookup_nvlist(nvl, "properties", &nvl_prop))
+		    != 0 ||
+		    (ret = nvlist_lookup_string(nvl, "name", &name)) != 0 ||
+		    (ret = nvlist_lookup_nvlist(nvl, "dmu_objset_stats",
+		    &nvl_dds)) != 0 ||
+		    (ret = dmu_objset_stat_nvlts(nvl_dds, &zc.zc_objset_stats))
+		    != 0) {
+			ret = EINVAL;
+			umem_free(buf, size);
+			goto out;
+		}
+
+		strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
+		umem_free(buf, size);
+
+		zc.zc_nvlist_dst_size = fnvlist_size(nvl_prop);
+		if ((ret = zcmd_expand_dst_nvlist(hdl, &zc))) {
+			if (ret == -1)
+				ret = ENOMEM;
+			goto out;
+		}
+
+		ret = nvlist_pack(nvl_prop, (char **) &zc.zc_nvlist_dst,
+		    &zc.zc_nvlist_dst_size, NV_ENCODE_NATIVE, 0);
+
+		zc.zc_nvlist_dst_filled = B_TRUE;
+
+		/*
+		 * Errors here do not make sense, so we bail.
+		 */
+		if (strchr(name, '#') != NULL) {
+			zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+			if (zhp == NULL) {
+				ret = ENOMEM;
+				goto out;
+			}
+			zhp->zfs_hdl = hdl;
+			switch (zc.zc_objset_stats.dds_type) {
+			case DMU_OST_ZFS:
+				zhp->zfs_head_type = ZFS_TYPE_FILESYSTEM;
+				break;
+			case DMU_OST_ZVOL:
+				zhp->zfs_head_type = ZFS_TYPE_VOLUME;
+				break;
+			default:
+				ret = EINVAL;
+				goto out;
+			}
+			nzhp = make_bookmark_handle(zhp, name, nvl_prop);
+			free(zhp);
+			if (nzhp == NULL)
+				continue;
+		} else if ((ret != 0) ||
+		    (nzhp = make_dataset_handle_zc(hdl, &zc)) == NULL) {
+			ret = EINVAL;
+			goto out;
+		}
+
+		if ((ret = func(nzhp, data)) != 0)
+			goto out;
+	}
+
+out:
+	close(fildes[0]);
+	close(fildes[1]);
+	zcmd_free_nvlists(&zc);
+	return ((ret < 0) ? ret : 0);
 }
 
 static int

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -126,8 +126,9 @@ zfs_iter_generic(libzfs_handle_t *hdl, const char *name, zfs_type_t type,
 
 	tnvl = zfs_type_to_nvl(type);
 	fnvlist_add_nvlist(opts, "type", tnvl);
+	fnvlist_add_int32(opts, "fd", fildes[1]);
 
-	if ((ret = lzc_list(name, fildes[1], opts)) != 0) {
+	if ((ret = lzc_list(name, opts)) != 0) {
 		fnvlist_free(opts);
 		close(fildes[0]);
 		close(fildes[1]);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1853,7 +1853,7 @@ static int
 recv_destroy(libzfs_handle_t *hdl, const char *name, int baselen,
     char *newname, recvflags_t *flags)
 {
-	zfs_cmd_t zc = {"\0"};
+	nvlist_t *opts = NULL;
 	int err = 0;
 	prop_changelist_t *clp;
 	zfs_handle_t *zhp;
@@ -1876,17 +1876,22 @@ recv_destroy(libzfs_handle_t *hdl, const char *name, int baselen,
 	if (err)
 		return (err);
 
-	zc.zc_objset_type = DMU_OST_ZFS;
-	zc.zc_defer_destroy = defer;
-	(void) strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
+	if (defer) {
+		opts = fnvlist_alloc();
+		fnvlist_add_boolean(opts, "defer");
+	}
 
 	if (flags->verbose)
-		(void) printf("attempting destroy %s\n", zc.zc_name);
-	err = ioctl(hdl->libzfs_fd, ZFS_IOC_DESTROY, &zc);
+		(void) printf("attempting destroy %s\n", name);
+	err = lzc_destroy_one(name, opts);
+
+	if (defer)
+		fnvlist_free(opts);
+
 	if (err == 0) {
 		if (flags->verbose)
 			(void) printf("success\n");
-		changelist_remove(clp, zc.zc_name);
+		changelist_remove(clp, name);
 	}
 
 	(void) changelist_postfix(clp);

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1495,6 +1495,8 @@ zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
 			    zprop_values(prop, type));
 			goto error;
 		}
+		*ivalp = 0;
+		*svalp = value;
 		break;
 
 	default:

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -311,7 +311,7 @@ lzc_snaprange_space(const char *firstsnap, const char *lastsnap,
 
 	err = lzc_ioctl(ZFS_IOC_SPACE_SNAPS, lastsnap, args, &result);
 	nvlist_free(args);
-	if (err == 0)
+	if (err == 0 && usedp != NULL)
 		*usedp = fnvlist_lookup_uint64(result, "used");
 	fnvlist_free(result);
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -554,6 +554,27 @@ lzc_send_space(const char *snapname, const char *fromsnap, uint64_t *spacep)
 	return (err);
 }
 
+/*
+ * Query number of bytes written in a given send stream
+ * for a given snapshot thus far.
+ */
+int
+lzc_send_progress(const char *snapname, int fd, uint64_t *bytesp)
+{
+	nvlist_t *args;
+	nvlist_t *result;
+	int err;
+
+	args = fnvlist_alloc();
+	fnvlist_add_int32(args, "fd", fd);
+	err = lzc_ioctl("zfs_send_progress", snapname, args, NULL, &result, 0);
+	nvlist_free(args);
+	if (err == 0)
+		*bytesp = fnvlist_lookup_uint64(result, "offset");
+	nvlist_free(result);
+	return (err);
+}
+
 static int
 recv_read(int fd, void *buf, int ilen)
 {

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -503,6 +503,28 @@ lzc_send(const char *snapname, const char *from, int fd,
 }
 
 /*
+ * Like lzc_send() but the additional flags and options are passed via an
+ * nvlist_t parameter.
+ */
+int
+lzc_send_ext(const char *snapname, const char *from, int fd, nvlist_t *params)
+{
+	nvlist_t *args;
+	int err;
+
+	args = fnvlist_alloc();
+	if (params != NULL)
+		fnvlist_merge(args, params);
+	fnvlist_add_int32(args, "fd", fd);
+	nvlist_remove_all(args, "fromsnap");
+	if (from != NULL)
+		fnvlist_add_string(args, "fromsnap", from);
+	err = lzc_ioctl("zfs_send", snapname, args, NULL, NULL, 0);
+	nvlist_free(args);
+	return (err);
+}
+
+/*
  * If fromsnap is NULL, a full (non-incremental) stream will be estimated.
  */
 int

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -220,6 +220,15 @@ lzc_clone(const char *fsname, const char *origin,
 	return (error);
 }
 
+int
+lzc_promote(const char *fsname)
+{
+	int error;
+
+	error = lzc_ioctl("zfs_promote", fsname, NULL, NULL, NULL, 0);
+	return (error);
+}
+
 /*
  * Creates snapshots.
  *

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -229,6 +229,19 @@ lzc_promote(const char *fsname, nvlist_t *opts)
 	return (error);
 }
 
+int
+lzc_set_props(const char *fsname, nvlist_t *props, boolean_t received)
+{
+	int error;
+	nvlist_t *opts = fnvlist_alloc();
+
+	if (received)
+		fnvlist_add_boolean(opts, "received");
+	error = lzc_ioctl("zfs_set_props", fsname, props, opts, NULL, 0);
+	nvlist_free(opts);
+	return (error);
+}
+
 /*
  * Creates snapshots.
  *

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -221,11 +221,11 @@ lzc_clone(const char *fsname, const char *origin,
 }
 
 int
-lzc_promote(const char *fsname)
+lzc_promote(const char *fsname, nvlist_t *opts)
 {
 	int error;
 
-	error = lzc_ioctl("zfs_promote", fsname, NULL, NULL, NULL, 0);
+	error = lzc_ioctl("zfs_promote", fsname, NULL, opts, NULL, 0);
 	return (error);
 }
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -230,15 +230,11 @@ lzc_promote(const char *fsname, nvlist_t *opts)
 }
 
 int
-lzc_set_props(const char *fsname, nvlist_t *props, boolean_t received)
+lzc_set_props(const char *fsname, nvlist_t *props, nvlist_t *opts)
 {
 	int error;
-	nvlist_t *opts = fnvlist_alloc();
 
-	if (received)
-		fnvlist_add_boolean(opts, "received");
 	error = lzc_ioctl("zfs_set_props", fsname, props, opts, NULL, 0);
-	nvlist_free(opts);
 	return (error);
 }
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -231,11 +231,12 @@ lzc_promote(const char *fsname, nvlist_t *opts)
 }
 
 int
-lzc_set_props(const char *fsname, nvlist_t *props, nvlist_t *opts)
+lzc_set_props(const char *fsname, nvlist_t *props, nvlist_t *opts,
+    nvlist_t **errlist)
 {
 	int error;
 
-	error = lzc_ioctl("zfs_set_props", fsname, props, opts, NULL, 0);
+	error = lzc_ioctl("zfs_set_props", fsname, props, opts, errlist, 0);
 	return (error);
 }
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
+ * Copyright (c) 2015 ClusterHQ. All rights reserved.
  */
 
 /*
@@ -116,7 +117,7 @@ libzfs_core_fini(void)
 }
 
 static int
-lzc_ioctl(zfs_ioc_t ioc, const char *name,
+lzc_ioctl_impl(zfs_ioc_t ioc, const char *name,
     nvlist_t *source, nvlist_t **resultp)
 {
 	zfs_cmd_t zc = {"\0"};
@@ -169,6 +170,29 @@ out:
 	return (error);
 }
 
+static int
+lzc_ioctl(const char *cmd, const char *name, nvlist_t *source,
+    nvlist_t *opts, nvlist_t **resultp, uint64_t version)
+{
+	nvlist_t *args = fnvlist_alloc();
+	int error;
+
+	ASSERT(*cmd);
+
+	fnvlist_add_string(args, "cmd", cmd);
+	if (source)
+		fnvlist_add_nvlist(args, "innvl", source);
+	if (opts)
+		fnvlist_add_nvlist(args, "opts", opts);
+	fnvlist_add_uint64(args, "version", version);
+
+	error = lzc_ioctl_impl(ZFS_IOC_LIBZFS_CORE, name, args, resultp);
+
+	fnvlist_free(args);
+
+	return (error);
+}
+
 int
 lzc_create(const char *fsname, dmu_objset_type_t type, nvlist_t *props)
 {
@@ -177,7 +201,7 @@ lzc_create(const char *fsname, dmu_objset_type_t type, nvlist_t *props)
 	fnvlist_add_int32(args, "type", type);
 	if (props != NULL)
 		fnvlist_add_nvlist(args, "props", props);
-	error = lzc_ioctl(ZFS_IOC_CREATE, fsname, args, NULL);
+	error = lzc_ioctl("zfs_create", fsname, args, NULL, NULL, 0);
 	nvlist_free(args);
 	return (error);
 }
@@ -191,7 +215,7 @@ lzc_clone(const char *fsname, const char *origin,
 	fnvlist_add_string(args, "origin", origin);
 	if (props != NULL)
 		fnvlist_add_nvlist(args, "props", props);
-	error = lzc_ioctl(ZFS_IOC_CLONE, fsname, args, NULL);
+	error = lzc_ioctl("zfs_clone", fsname, args, NULL, NULL, 0);
 	nvlist_free(args);
 	return (error);
 }
@@ -233,7 +257,7 @@ lzc_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t **errlist)
 	if (props != NULL)
 		fnvlist_add_nvlist(args, "props", props);
 
-	error = lzc_ioctl(ZFS_IOC_SNAPSHOT, pool, args, errlist);
+	error = lzc_ioctl("zfs_snapshot", pool, args, NULL, errlist, 0);
 	nvlist_free(args);
 
 	return (error);
@@ -283,7 +307,7 @@ lzc_destroy_snaps(nvlist_t *snaps, boolean_t defer, nvlist_t **errlist)
 	if (defer)
 		fnvlist_add_boolean(args, "defer");
 
-	error = lzc_ioctl(ZFS_IOC_DESTROY_SNAPS, pool, args, errlist);
+	error = lzc_ioctl("zfs_destroy_snaps", pool, args, NULL, errlist, 0);
 	nvlist_free(args);
 
 	return (error);
@@ -309,7 +333,7 @@ lzc_snaprange_space(const char *firstsnap, const char *lastsnap,
 	args = fnvlist_alloc();
 	fnvlist_add_string(args, "firstsnap", firstsnap);
 
-	err = lzc_ioctl(ZFS_IOC_SPACE_SNAPS, lastsnap, args, &result);
+	err = lzc_ioctl("zfs_space_snaps", lastsnap, args, NULL, &result, 0);
 	nvlist_free(args);
 	if (err == 0 && usedp != NULL)
 		*usedp = fnvlist_lookup_uint64(result, "used");
@@ -378,7 +402,7 @@ lzc_hold(nvlist_t *holds, int cleanup_fd, nvlist_t **errlist)
 	if (cleanup_fd != -1)
 		fnvlist_add_int32(args, "cleanup_fd", cleanup_fd);
 
-	error = lzc_ioctl(ZFS_IOC_HOLD, pool, args, errlist);
+	error = lzc_ioctl("zfs_hold", pool, args, NULL, errlist, 0);
 	nvlist_free(args);
 	return (error);
 }
@@ -418,7 +442,7 @@ lzc_release(nvlist_t *holds, nvlist_t **errlist)
 	(void) strlcpy(pool, nvpair_name(elem), sizeof (pool));
 	pool[strcspn(pool, "/@")] = '\0';
 
-	return (lzc_ioctl(ZFS_IOC_RELEASE, pool, holds, errlist));
+	return (lzc_ioctl("zfs_release", pool, holds, NULL, errlist, 0));
 }
 
 /*
@@ -433,7 +457,7 @@ lzc_get_holds(const char *snapname, nvlist_t **holdsp)
 {
 	int error;
 	nvlist_t *innvl = fnvlist_alloc();
-	error = lzc_ioctl(ZFS_IOC_GET_HOLDS, snapname, innvl, holdsp);
+	error = lzc_ioctl("zfs_get_holds", snapname, innvl, NULL, holdsp, 0);
 	fnvlist_free(innvl);
 	return (error);
 }
@@ -473,7 +497,7 @@ lzc_send(const char *snapname, const char *from, int fd,
 		fnvlist_add_string(args, "fromsnap", from);
 	if (flags & LZC_SEND_FLAG_EMBED_DATA)
 		fnvlist_add_boolean(args, "embedok");
-	err = lzc_ioctl(ZFS_IOC_SEND_NEW, snapname, args, NULL);
+	err = lzc_ioctl("zfs_send", snapname, args, NULL, NULL, 0);
 	nvlist_free(args);
 	return (err);
 }
@@ -491,7 +515,7 @@ lzc_send_space(const char *snapname, const char *fromsnap, uint64_t *spacep)
 	args = fnvlist_alloc();
 	if (fromsnap != NULL)
 		fnvlist_add_string(args, "fromsnap", fromsnap);
-	err = lzc_ioctl(ZFS_IOC_SEND_SPACE, snapname, args, &result);
+	err = lzc_ioctl("zfs_send_space", snapname, args, NULL, &result, 0);
 	nvlist_free(args);
 	if (err == 0)
 		*spacep = fnvlist_lookup_uint64(result, "space");
@@ -619,7 +643,7 @@ lzc_rollback(const char *fsname, char *snapnamebuf, int snapnamelen)
 	int err;
 
 	args = fnvlist_alloc();
-	err = lzc_ioctl(ZFS_IOC_ROLLBACK, fsname, args, &result);
+	err = lzc_ioctl("zfs_rollback", fsname, args, NULL, &result, 0);
 	nvlist_free(args);
 	if (err == 0 && snapnamebuf != NULL) {
 		const char *snapname = fnvlist_lookup_string(result, "target");
@@ -655,7 +679,7 @@ lzc_bookmark(nvlist_t *bookmarks, nvlist_t **errlist)
 	(void) strlcpy(pool, nvpair_name(elem), sizeof (pool));
 	pool[strcspn(pool, "/#")] = '\0';
 
-	error = lzc_ioctl(ZFS_IOC_BOOKMARK, pool, bookmarks, errlist);
+	error = lzc_ioctl("zfs_bookmark", pool, bookmarks, NULL, errlist, 0);
 
 	return (error);
 }
@@ -684,7 +708,7 @@ lzc_bookmark(nvlist_t *bookmarks, nvlist_t **errlist)
 int
 lzc_get_bookmarks(const char *fsname, nvlist_t *props, nvlist_t **bmarks)
 {
-	return (lzc_ioctl(ZFS_IOC_GET_BOOKMARKS, fsname, props, bmarks));
+	return (lzc_ioctl_impl(ZFS_IOC_GET_BOOKMARKS, fsname, props, bmarks));
 }
 
 /*
@@ -717,7 +741,8 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 	(void) strlcpy(pool, nvpair_name(elem), sizeof (pool));
 	pool[strcspn(pool, "/#")] = '\0';
 
-	error = lzc_ioctl(ZFS_IOC_DESTROY_BOOKMARKS, pool, bmarks, errlist);
+	error = lzc_ioctl("zfs_destroy_bookmarks", pool, bmarks, NULL, errlist,
+	    0);
 
 	return (error);
 }

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -631,9 +631,8 @@ lzc_receive(const char *snapname, nvlist_t *props, const char *origin,
 	/* zc_name is name of containing filesystem */
 	(void) strlcpy(zc.zc_name, snapname, sizeof (zc.zc_name));
 	atp = strchr(zc.zc_name, '@');
-	if (atp == NULL)
-		return (EINVAL);
-	*atp = '\0';
+	if (atp != NULL)
+		*atp = '\0';
 
 	/* if the fs does not exist, try its parent. */
 	if (!lzc_exists(zc.zc_name)) {
@@ -643,9 +642,6 @@ lzc_receive(const char *snapname, nvlist_t *props, const char *origin,
 		*slashp = '\0';
 
 	}
-
-	/* zc_value is full name of the snapshot to create */
-	(void) strlcpy(zc.zc_value, snapname, sizeof (zc.zc_value));
 
 	if (props != NULL) {
 		/* zc_nvlist_src is props to set */
@@ -663,6 +659,20 @@ lzc_receive(const char *snapname, nvlist_t *props, const char *origin,
 	if (error != 0)
 		goto out;
 	zc.zc_begin_record = drr.drr_u.drr_begin;
+
+	/* zc_value is full name of the snapshot to create */
+	(void) strlcpy(zc.zc_value, snapname, sizeof (zc.zc_value));
+
+	/* if snapshot name is not provided try to take it from the stream */
+	atp = strchr(zc.zc_value, '@');
+	if (atp == NULL) {
+		atp = strchr(zc.zc_begin_record.drr_toname, '@');
+		if (atp == NULL)
+			return (EINVAL);
+		if (strlen(zc.zc_value) + strlen(atp) >= sizeof(zc.zc_value))
+			return (ENAMETOOLONG);
+		strcat(zc.zc_value, atp);
+	}
 
 	/* zc_cookie is fd to read from */
 	zc.zc_cookie = fd;

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -941,14 +941,12 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
  * stream NULL record is returned.
  */
 int
-lzc_list(const char *name, int fdin, nvlist_t *opts)
+lzc_list(const char *name, nvlist_t *opts)
 {
 	int error;
 	nvlist_t *innvl = fnvlist_alloc();
 
-	fnvlist_add_int32(innvl, "fd", fdin);
 	error = lzc_ioctl("zfs_list", name, innvl, opts, NULL, 0);
-	fnvlist_free(innvl);
 
 	return (error);
 }

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -364,14 +364,7 @@ lzc_snaprange_space(const char *firstsnap, const char *lastsnap,
 boolean_t
 lzc_exists(const char *dataset)
 {
-	/*
-	 * The objset_stats ioctl is still legacy, so we need to construct our
-	 * own zfs_cmd_t rather than using zfsc_ioctl().
-	 */
-	zfs_cmd_t zc = {"\0"};
-
-	(void) strlcpy(zc.zc_name, dataset, sizeof (zc.zc_name));
-	return (ioctl(g_fd, ZFS_IOC_OBJSET_STATS, &zc) == 0);
+	return (lzc_ioctl("zfs_exists", dataset, NULL, NULL, NULL, 0) == 0);
 }
 
 /*

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -127,7 +127,8 @@ lzc_ioctl_impl(zfs_ioc_t ioc, const char *name,
 
 	ASSERT3S(g_refcount, >, 0);
 
-	(void) strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
+	if (name)
+		(void) strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
 
 	packed = fnvlist_pack(source, &size);
 	zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
@@ -804,6 +805,150 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 
 	error = lzc_ioctl("zfs_destroy_bookmarks", pool, bmarks, NULL, errlist,
 	    0);
+
+	return (error);
+}
+
+/*
+ * List DSL directory/directories
+ *
+ * This is an asynchronous API call. The caller passes a file descriptor
+ * through which output is received. The file descriptor should typically be
+ * the send side of a pipe, but this is not required.
+ *
+ * Preliminary error checks are done prior to the start of output and if
+ * successful, a return code of zero is provided. If unsuccessful, a non-zero
+ * error code is passed.
+ *
+ * The opts field is an nvlist which supports the following properties:
+ *
+ * Name		Type		Description
+ * "recurse"	boolean/uint64	List output for children.
+ * "type"	nvlist		List only types specified.
+ *
+ * If the passed name is that of a bookmark or snapshot, the recurse field is
+ * ignored. If all children are desired, recurse should be set to be a boolean
+ * type. If a recursion limit is desired, recurses hould be a uint64_t. If no
+ * type is specified, a default behavior consistent with the zfs list command
+ * is provided. Valid children of the type nvlist are:
+ *
+ * Name		Type		Description
+ * "all"	boolean		List output for all types
+ * "bookmark"	boolean		List output for bookmarks
+ * "filesystem"	boolean		List output for filesystems
+ * "snap"	boolean		List output for snapshots
+ * "snapshot"	boolean		List output for snapshots
+ * "volume"	boolean		List output for volumes
+ *
+ * Whenever a boolean type is specified, any type may be passed and be
+ * considered boolean. However, future extensions may accept alternate types
+ * and consequently, backward compatibility is only guarenteed to callers
+ * passing a boolean type that contains no value. A boolean that contains
+ * B_TRUE or B_FALSE is considered a separate type from a boolean that contains
+ * no value. Additionally, future enhancements to zfs may create a new type and
+ * callers that only wish to handle existing types should specify them
+ * explicitly rather than relying on the default behavior.
+ *
+ * The parent-child relationship is obeyed such all children of each
+ * pool/directory are output alongside their parents. However, no guarantees
+ * are made with regard to post-order/pre-order traversal or the order of
+ * bookmarks/snapshots, such that the order is allowed to change. Userland
+ * applications that are sensitive to a particular output order are expected to
+ * sort.
+ *
+ * The output consists of a record header followed immediately by XDR-encoded
+ * nvlist. The header format is as follows:
+ *
+ * Offset	Size		Description
+ * 0 bytes	4 bytes		XDR-nvlist size (unsigned)
+ * 4 bytes	1 byte		Header extension space (unsigned)
+ * 5 bytes	1 byte		Return code (unsigned)
+ * 6 bytes	1 byte		Endian bit (0 is BE, 1 is LE)
+ * 7 bytes	1 byte		Reserved
+ *
+ * Errors obtaining information for any record will be contained in the return
+ * code. The output for any record whose header return code contains an error
+ * is a XDR encoded nvlist whose contents are undefined, unless the size
+ * provided in the header is zero, in which case the output for that record is
+ * empty. The receiver is expected to check the endian bit field before
+ * processing the XDR-nvlist size and perform a byte-swap operation on the
+ * value should the endian-ness differ.
+ *
+ * Non-zero values in the reserved field and upper bits of the endian field
+ * imply a back-incompatible change. If the header extension field is non-zero
+ * when neither the reserved field nor the upper bits of the endian field are
+ * non-zero, the header should be assumed to have been extended in a
+ * backward-compatible way and the XDR-nvlist of the specified size shall
+ * follow the extended header. The lzc_list() library call will always request
+ * API version 0 request as part of the ioctl to userland.  Consequently, the
+ * kernel will return an API version 0 compatible-stream unless a change is
+ * requested via a future extension to the opts nvlist.
+ *
+ * The nvlist will have the following members:
+ *
+ * Name			Type		Description
+ * "name"		string		SPA/DSL name
+ * "dmu_objset_stats"	nvlist		DMU Objset Stats
+ * "properties"		nvlist		DSL properties
+ *
+ * Additional members may be added in future extensions.
+ *
+ * The "dmu_objset_stats" will have the following members:
+ *
+ * Name			Type		Description
+ * "dds_num_clones"	uint64_t	Number of clones
+ * "dds_creation_txg"	uint64_t	Creation transaction group
+ * "dds_guid"		uint64_t	Globally unique identifier
+ * "dds_type"		string		Type
+ * "dds_is_snapshot"	boolean		Is a snapshot
+ * "dds_inconsistent"	boolean		Is being received or destroyed
+ * "dds_origin"		string		Name of parent
+ *
+ * Additional members may be added in future extensions.
+ *
+ * The "dds_" prefix stands for "DSL Dataset". "dds_type" is a string
+ * representation of internal object types. Valid values at this time are:
+ *
+ * Name		Public	Description
+ * "NONE"	No	Uninitialized value
+ * "META"	No	Metadata
+ * "ZPL"	Yes	Dataset
+ * "ZVOL"	Yes	Volume
+ * "OTHER"	No	Undefined
+ * "ANY"	No	Open
+ *
+ * Only the public values will be returned for any output. The return of a
+ * value not on this list implies a record for a new storage type. The output
+ * should be consistent with existing types and the receiver can elect to
+ * either handle it in a manner consistent with existing types or skip it.
+ * Under no circumstance will an unlisted type be returned when types were
+ * explicitly provided via the opts nvlist.
+ *
+ * On bookmarks, the "dmu_objset_stats" of the parent DSL Dataset shall be
+ * returned. Consequently, "dds_is_snapshot" shall be false and identification
+ * of bookmarks shall be done by checking for the '#' character in the "name"
+ * member of the top level nvlist. This is done so that the type of the
+ * bookmarked DSL dataset may be known.
+ *
+ * End of output shall be signified by NULL record header. Userland is expected
+ * to close the file descriptor. Early termination can be signaled from
+ * userland by closing the file descriptor.
+ *
+ * The design of the output is intended to enable userland to perform readahead
+ * on the file descriptor. On certain platforms, libc may provide output
+ * buffering. Userland libraries and applications electing to perform readahead
+ * should take care not to block on a partially filled buffer when an end of
+ * stream NULL record is returned.
+ */
+int
+lzc_list(const char *name, int fdin, nvlist_t *opts)
+{
+	int error;
+	nvlist_t *innvl = fnvlist_alloc();
+
+	fnvlist_add_int32(innvl, "fd", fdin);
+	error = lzc_ioctl("zfs_list", name, innvl, opts, NULL, 0);
+	fnvlist_free(innvl);
 
 	return (error);
 }

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -810,6 +810,32 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 }
 
 /*
+ * Resets a property on a  DSL directory (i.e. filesystems, volumes, snapshots)
+ * to its original value.
+ *
+ * The following are the valid properties in opts, all of which are booleans:
+ *
+ * "received" - resets property value to from `zfs recv` if it set a value
+ */
+int
+lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts)
+{
+	nvlist_t *args;
+	int error;
+
+	if (fsname == NULL || (propname == NULL ||
+	    strlen(fsname) == 0 || strlen(propname) == 0))
+		return (EINVAL);
+
+	args = fnvlist_alloc();
+	fnvlist_add_string(args, "prop", propname);
+	error = lzc_ioctl("zfs_inherit", fsname, args, opts, NULL, 0);
+	fnvlist_free(args);
+
+	return (error);
+}
+
+/*
  * Rename DSL directory (i.e. filesystems, volumes, snapshots)
  *
  * The opts flag accepts a boolean named "recursive" to signal that the

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -810,6 +810,48 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 }
 
 /*
+ * Rename DSL directory (i.e. filesystems, volumes, snapshots)
+ *
+ * The opts flag accepts a boolean named "recursive" to signal that the
+ * mountpoint property on children should be updated.
+ *
+ * The following are the valid properties in opts, all of which are booleans:
+ *
+ * "recursive" - Rename mountpoints on child DSL directories
+ *
+ * If a recursive rename is done, an error occurs and errname is initialized, a
+ * string will be allocated with strdup() and returned via it. The caller must
+ * free it with strfree().
+ */
+int
+lzc_rename(const char *oldname, const char *newname, nvlist_t *opts,
+    char **errname)
+{
+	nvlist_t *args, *errlist;
+	int error;
+
+	if (newname == NULL || (oldname == NULL ||
+	    strlen(oldname) == 0 || strlen(newname) == 0))
+		return (EINVAL);
+
+	args = fnvlist_alloc();
+	errlist = (errname != NULL) ? fnvlist_alloc() : NULL;
+	fnvlist_add_string(args, "newname", newname);
+	error = lzc_ioctl("zfs_rename", oldname, args, opts, &errlist, 0);
+
+	if (error && errname != NULL) {
+		const char *name = fnvlist_lookup_string(errlist, "name");
+		*errname = strdup(name);
+	}
+
+	fnvlist_free(args);
+	if (errlist)
+		fnvlist_free(errlist);
+
+	return (error);
+}
+
+/*
  * List DSL directory/directories
  *
  * This is an asynchronous API call. The caller passes a file descriptor

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -836,6 +836,34 @@ lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts)
 }
 
 /*
+ * Destroys a DSL directory that is either a filesystems or a volume.
+ * Destroying snapshots and bookmarks is not currently supported. Call
+ * lzc_destroy_snaps and lzc_destroy_bookmarks for those respectively.
+ *
+ * The only currently valud property is the boolean "defer". It makes
+ * destruction asynchronous such that the only error code back is if we try to
+ * destroy something that does not exist. The caller must unmount the dataset
+ * before calling this. Otherwise, it will fail.
+ */
+
+int
+lzc_destroy_one(const char *fsname, nvlist_t *opts)
+{
+	nvlist_t *args;
+	int error;
+
+	if (fsname == NULL ||
+	    strlen(fsname) == 0)
+		return (EINVAL);
+
+	args = fnvlist_alloc();
+	error = lzc_ioctl("zfs_destroy", fsname, args, opts, NULL, 0);
+	fnvlist_free(args);
+
+	return (error);
+}
+
+/*
  * Rename DSL directory (i.e. filesystems, volumes, snapshots)
  *
  * The opts flag accepts a boolean named "recursive" to signal that the

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = man1 man5 man8
+SUBDIRS = man1 man3 man5 man8

--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -1,0 +1,30 @@
+dist_man_MANS = \
+	libzfs_core_fini.3 \
+	libzfs_core.h.3 \
+	libzfs_core_init.3 \
+	lzc_bookmark.3 \
+	lzc_clone.3 \
+	lzc_create.3 \
+	lzc_destroy_bookmarks.3 \
+	lzc_destroy_one.3 \
+	lzc_destroy_snaps.3 \
+	lzc_exists.3 \
+	lzc_get_bookmarks.3 \
+	lzc_get_holds.3 \
+	lzc_hold.3 \
+	lzc_inherit.3 \
+	lzc_list.3 \
+	lzc_promote.3 \
+	lzc_receive.3 \
+	lzc_release.3 \
+	lzc_rollback.3 \
+	lzc_send.3 \
+	lzc_send_ext.3 \
+	lzc_send_progress.3 \
+	lzc_send_space.3 \
+	lzc_set_props.3 \
+	lzc_snaprange_space.3 \
+	lzc_snapshot.3
+
+install-data-local:
+	$(INSTALL) -d -m 0755 "$(DESTDIR)$(mandir)/man3"

--- a/man/man3/libzfs_core.h.3
+++ b/man/man3/libzfs_core.h.3
@@ -1,0 +1,118 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH libzfs_core.h 3 "2015 JUL 3" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual. The location of
+the header might vary on different systems. Compilation with GCC on Linux
+systems requires the addition of -I/usr/include/libspl -I/usr/include/libzfs to
+GCC's parameters to include the proper headers.
+
+.SH NAME
+libzfs_core.h \- Stable OpenZFS Management C API
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+.SH DESCRIPTION
+.LP
+The
+.IR <libzfs_core.h>
+header shall define the following function prototype headers:
+.sp
+.RS 4
+.nf
+
+\fBint\fR \fBlibzfs_core_init\fR(\fBvoid\fR);
+.p
+\fBvoid\fR \fBlibzfs_core_fini\fR(\fBvoid\fR);
+.sp
+\fBint\fR \fBlzc_list\fR(\fBconst char *\fR\fIname\fR, \fBnvlist_t *\fR\fIopts\fR)
+.p
+\fBint\fR \fBlzc_snapshot\fR(\fBnvlist_t *\fR\fIsnaps\fR, \fBnvlist_t *\fR\fIprops\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.p
+\fBint\fR \fBlzc_rollback\fR(\fBconst char *\fR\fIfsname\fR, \fBchar *\fR\fIsnapnamebuf\fR, \fBint\fR \fIsnapnamelen\fR);
+.p
+\fBint\fR \fBlzc_create\fR(\fBconst char *\fR\fIfsname\fR, \fBdmu_objset_type_t\fR \fItype\fR, \fBnvlist_t *\fR\fIprops\fR);
+.p
+\fBint\fR \fBlzc_clone\fR(\fBconst char *\fR\fIfsname\fR, \fBconst char *\fR \fIorigin\fR, \fBnvlist_t *\fR\fIprops\fR);
+.p
+\fBint\fR \fBlzc_promote\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIopts\fR);
+.p
+\fBint\fR \fBlzc_set_props\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t*\fR\fIprops\fR, \fBnvlist_t *\fR\fIopts\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.p
+\fBint\fR \fBlzc_destroy_one\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIopts\fR);
+.p
+\fBint\fR \fBlzc_destroy_snaps\fR(\fBnvlist_t *\fR\fIsnaps\fR, \fBboolean_t\fR \fIdefer\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.p
+\fBint\fR \fBlzc_bookmark\fR(\fBnvlist_t *\fR\fIbookmarks\fR, \fBnvlist_t
+.p
+\fBint\fR \fBlzc_get_bookmarks\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIprops\fR, \fBnvlist_t **\fR\fIbmarks\fR);
+.p
+\fBint\fR \fBlzc_destroy_bookmarks\fR(\fBnvlist_t *\fR\fIbmarks\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.sp
+\fBint\fR \fBlzc_snaprange_space\fR(\fBconst char *\fR\fIfirstsnap\fR, \fBconst char *\fR\fIlastsnap\fR, \fBuint64_t *\fR\fIusedp\fR);
+.sp
+\fBint\fR \fBlzc_hold\fR(\fBnvlist_t *\fR\fIholds\fR, \fBint\fR \fIcleanup_fd\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.p
+\fBint\fR \fBlzc_release\fR(\fBnvlist_t *\fR\fIholds\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.p
+\fBint\fR \fBlzc_get_holds\fR(\fBconst char *\fR\fIsnapname\fR, \fBnvlist_t **\fR\fIholdsp\fR);
+.sp
+\fBint\fR \fBlzc_inherit\fR(\fBconst char *\fR\fIfsname\fR, \fBconst char *\fR fIpropname\fR, \fBnvlist_t *\fR\fIopts\fR);
+.p
+int lzc_rename(const char *oldname, const char *newname, nvlist_t *opts, char **errname);
+
+\fBint\fR \fBlzc_send\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char *\fR\fIfrom\fR, \fBint\fR \fIfd\fR, \fBenum lzc_send_flags\fR \fIflags);
+.p
+\fBint\fR \fBlzc_send_ext\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char *\fR\fIfrom\fR, \fBint\fR \fIfd\fR, \fBnvlist_t *\fR\fIparams\fR);
+.p
+\fBint\fR \fBlzc_receive\fR(\fBconst char *\fR\fIsnapname\fR, \fBnvlist_t *\fR\fIprops\fR, \fBconst char *\fR\fIorigin\fR, \fBboolean_t\fR \fIforce\fR, \fBint\fR \fIfd\fR);
+.p
+\fBint\fR \fBlzc_send_space\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char *\fR\fIfrom\fR, \fBuint64_t *\fR\fIspacep\fR);
+.p
+\fBint\fR \fBlzc_send_progress\fR(\fBconst char *\fR\fIsnapname\fR, \fBint\fR \fIfd\fR, \fBuint64_t *\fR\fIbytesp\fR);
+.sp
+\fBboolean_t\fR \fBlzc_exists\fR(\fBconst char *\fR\fIdataset\fR);
+
+.fi \fR
+.P
+.RE
+.P
+The
+.IR <libzfs_core.h> 
+header shall define the following type for lzc_send:
+.sp
+.RS 4
+.nf
+\fB
+
+enum lzc_send_flags {
+	LZC_SEND_FLAG_EMBED_DATA = 1 << 0
+};
+.fi \fR
+.SH "NOTES"
+.LP
+The above functions have their own man pages in section 3 of the system manual.

--- a/man/man3/libzfs_core_fini.3
+++ b/man/man3/libzfs_core_fini.3
@@ -1,0 +1,1 @@
+.so man3/libzfs_core_init.3

--- a/man/man3/libzfs_core_init.3
+++ b/man/man3/libzfs_core_init.3
@@ -1,0 +1,65 @@
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH libzfs_core_init 3 "2015 JUL 3" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlibzfs_core_init\fR(\fBvoid\fR);
+.sp
+\fBvoid\fR \fBlibzfs_core_fini\fR(\fBvoid\fR);
+
+.SH NAME
+libzfs_core_init, libzfs_core_fini \- Initialize and deinitialize libzfs_core library.
+
+.SH DESCRIPTION
+.LP
+The
+\fBlibzfs_core_init\fR()
+function is a singleton constructor for the libzfs_core library. It should be called once at program initialization. Multiple calls to
+\fBlibzfs_core_init\fR()
+are fine provided that they be matched by an equal number of alls to the
+\fBlibzfs_core_fini\fR()
+function.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion of the \fBlibzfs_core_init\fR() function, 0 is returned and a file descriptor is open for /dev/zfs. Otherwise, an error is returned.
+.sp
+The \fBlibzfs_core_fini\fR() function returns no value and does not fail.
+.BR
+.SH ERRORS
+.sp
+.LP
+The \fBlibzfs_core_init\fR() function shall fail if \fBopen\fR(2) of /dev/zfs
+fails. In this situation, the error code from \fBopen\fR(2) will be returned.
+
+.SH "SEE ALSO"
+.sp
+.LP
+"\fIlibzfs_core.h\fR(3)", "\fIopen\fR(2)"

--- a/man/man3/lzc_bookmark.3
+++ b/man/man3/lzc_bookmark.3
@@ -1,0 +1,161 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_bookmark 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_bookmark\fR(\fBnvlist_t *\fR\fIbookmarks\fR, \fBnvlist_t
+**\fR\fIerrlist\fR);
+
+.SH NAME
+lzc_bookmark \- Creates bookmarks from snapshot
+
+.SH DESCRIPTION
+.LP
+The \fBlibzfs_snapshot\fR() function creates atomic snapshots of all ZFS
+datasets and/or volumes named in the \fIsnaps\fR nvlist.
+
+.I bookmarks
+shall be a nvlist containing strings whose keys are bookmark names and values
+are snapshot names to specify which bookmarks to create.  All bookmarks and
+snapshots must be inside the same pool.
+
+.I errlist
+shall contain a handle that shall be used to store a pointer to a library
+allocated nvlist when non-NULL and the operation for at least one hold fails.
+The names of the holds shall be the keys while the values shall contain the
+error codes and be of type int32. Holds that failed to release because they did
+not exist shall also have an entry added. It shall not be touched otherwise.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_bookmark()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+A bookmark with a name specified in \fIbookmarks\fR already exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+Multiple bookmarks were specified in \fIbookmarks\fR with the same name.
+.sp
+The snapshot for a bookmark is not a syntactically valid snapshot.
+.sp
+\fIbookmarks\fR is not a valid nvlist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+A bookmark name in the \fIbookmarks\fR nvlist exceeds 255 characters (excluding
+NULL termination character).
+.sp
+A snapshot name in the \fIbookmarks\fR nvlist exceeds 255 characters (excluding
+NULL termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+A snapshot specified in \fIbookmarks\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIbookmarks\fR to the
+kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+The bookmark feature flag is not enabled on this pool.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+Multiple pools specified.
+.sp
+Multiple snapshots per filesystem specified.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_clone.3
+++ b/man/man3/lzc_clone.3
@@ -1,0 +1,156 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_clone 3 "2015 JUL 3" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_clone\fR(\fBconst char *\fR\fIfsname\fR, \fBconst char *\fR \fIorigin\fR, \fBnvlist_t *\fR\fIprops\fR);
+
+.SH NAME
+lzc_clone \- Creates a clone from a snapshot
+
+.SH DESCRIPTION
+.LP
+The
+\fBlibzfs_clone\fR()
+function creates a ZFS dataset or volume named
+.I fsname
+from the snapshot
+.fs origin .
+Properties may optionally be set using 
+.I props .
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_clone()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEDQUOT\fR\fR
+.ad
+.RS 13n
+Creation of the clone will require storage space in excess of the filesystem
+quota.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+A dataset named \fIfsname\fR already exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is not syntactically correct. This includes situations where bookmarks, snapshots or holds are specified.
+.sp
+The snapshot name \fIorigin\fR is not syntactically correct. This includes the case of attempting to clone a non-snapshot.
+.sp
+The nvlist_t \fIprops\fR could not be understood by the kernel as being NULL or a nvlist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR exceeds 255 characters (excluding NULL
+termination character).
+.sp
+The snapshot name \fIorigin\fR nvlist exceeds 255 characters (excluding NULL
+termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loadng unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIprops\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEOVERFLOW\fR\fR
+.ad
+.RS 13n
+Specified volume size through \fIprops\fR exceeds system supported device size.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+Attempted to clone across pools.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_create.3
+++ b/man/man3/lzc_create.3
@@ -1,0 +1,142 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_create 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_create\fR(\fBconst char *\fR\fIfsname\fR, \fBdmu_objset_type_t\fR \fItype\fR, \fBnvlist_t *\fR\fIprops\fR);
+
+.SH NAME
+lzc_create \- Create a ZFS dataset or volume
+
+.SH DESCRIPTION
+.LP
+The
+\fBlibzfs_create\fR()
+function creates a dataset or zvol according to \fItype\fR. Optional properties
+are passed through \fIprops\fR.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_inherit()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is invalid.
+.sp
+The dataset type \fItype\fR is invalid.
+.sp
+The nvlist \fIprops\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR exceeds 255 characters (excluding NULL
+termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIprops\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+The requested ZPL version is not supported.
+.sp
+A feature has been requested (e.g. normalization) that hte requested ZPL version doe sont support.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEOVERFLOW\fR\fR
+.ad
+.RS 13n
+Specified volume size exceeds system supported device size.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_destroy_bookmarks.3
+++ b/man/man3/lzc_destroy_bookmarks.3
@@ -1,0 +1,133 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_destroy_bookmarks 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_destroy_bookmarks\fR(\fBnvlist_t *\fR\fIbmarks\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+
+.SH NAME
+lzc_destroy_bookmarks \- Destroys bookmarks
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_destroy_bookmarks\fR() function shall atomically destroy bookmarks
+specified within a pool. The pool is determined implicitly from the list of
+bookmarks. If \fIerrlist\fR is specified and destruction of a bookmark fails
+(e.g. specified name too long), it will be allocated and updated to contain a
+list of bookmarks where the operation failed. The keys of the list will be the
+full bookmark names while the values will be int32 error codes.
+.sp
+Bookmarks that do not exist will be silently ignored.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the bookmarks where an error
+occurred and \fIerrlist\fR is populated with more specific information if a
+pointer is provided. \fIerrlist\fR shall contain keys with the snapshot names
+and int32 values of the error codes. The caller must call \fBnvlist_free\fR()
+on \fIerrlist\fR if this occurs.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_destroy_bookmarks()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+Invalid boomark name specified in \fIbmarks\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+Bookmark name specified in \fIbmarks\fR is too long.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIbmarks\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+Bookmarks from different pools were specified.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_destroy_one.3
+++ b/man/man3/lzc_destroy_one.3
@@ -1,0 +1,150 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_destroy_one 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_destroy_one\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIopts\fR);
+
+.SH NAME
+lzc_destroy_one \- Destroys a dataset or volume
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_destroy_one\fR() function shall destroys a dataset or a volume.
+Destroying snapshots and bookmarks is not currently supported. Call
+lzc_destroy_snaps and lzc_destroy_bookmarks for those respectively.
+
+The only currently valud property is the boolean "defer". It makes destruction
+asynchronous such that the only error code back is if we try to destroy
+something that does not exist. The caller must unmount the dataset before
+calling this. Otherwise, it will fail.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the bookmarks where an error
+occurred and \fIerrlist\fR is populated with more specific information if a
+pointer is provided. \fIerrlist\fR shall contain keys with the snapshot names
+and int32 values of the error codes. The caller must call \fBnvlist_free\fR()
+on \fIerrlist\fR if this occurs.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_destroy_one()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEBUSY\fR\fR
+.ad
+.RS 13n
+Dataset named \fIdataset\fR has a long hold from a zfs send stream or a user
+hold from \fBlzc_hold\fR().
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+The dataset or volume \fIfsname\fR has children in its pool's namespace.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The string \fIfsname\fR is an invalid name for a dataset or volume.
+.sp
+The \fIopts\fR nvlist is neither NULL nor a valid nvlist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIfsname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The string \fIfsname\fR does not name a dataset that exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIbmarks\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+\fIdefer\fR specified, but pool version predates version 18
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_hold\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_destroy_snaps.3
+++ b/man/man3/lzc_destroy_snaps.3
@@ -1,0 +1,159 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_destroy_snaps 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_destroy_snaps\fR(\fBnvlist_t *\fR\fIsnaps\fR, \fBboolean_t\fR \fIdefer\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+
+.SH NAME
+lzc_destroy_snaps \- Destroy snapshots
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_destroy_snaps\fR() function destroys snapshots specified via strings
+through the nvlist \fRsnaps\fR. They must all be in the same pool.
+.sp
+Snapshots that do not exist will be silently ignored.
+.sp
+If \fIdefer\fR is not set, and a snapshot has user holds or clones, the
+destroy operation will fail and none of the snapshots will be
+destroyed.
+.sp
+If \fIdefer\fR is set, and a snapshot has user holds or clones, it will be
+marked for deferred destruction, and will be destroyed when the last hold
+or clone is removed/destroyed.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. This means that all snapshots were
+destroyed (excluding those that did not exist) or were marked for later
+distruction if \fIdefer\fR is set.
+.sp
+On error, an error is returned from one of the snapshots where an error
+occurred and \fIerrlist\fR is populated with more specific information if a
+pointer is provided. \fIerrlist\fR shall contain keys with the snapshot names
+and int32 values of the error codes. The caller must call \fBnvlist_free\fR()
+on \fIerrlist\fR if this occurs.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_destroy_snaps()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEBUSY\fR\fR
+.ad
+.RS 13n
+Snapshot held by a user hold and \fIdefer\fR is not specified.
+.sp
+Snapshot held by a zfs send stream and \fIdefer\fR is not specified.
+.sp
+Snapshot held by an open file hanle or program's present working directory and
+\fIdefer\fR is not specified.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+This snapshot is the parent of clones and cannot be deleted.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+No snaphsots specified in \fIsnaps\fR.
+.sp
+The nvlist \fIsnaps\fR is not a valid nvlist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+Snapshot name specified in \fIsnaps\fR is too long.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIprops\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+\fIdeferred\fR specified on pool that is earlier than version 18.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_exists.3
+++ b/man/man3/lzc_exists.3
@@ -1,0 +1,68 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_exists 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBboolean_t\fR \fBlzc_exists\fR(\fBconst char *\fR\fIdataset\fR);
+
+.SH NAME
+lzc_exists \- Test for dataset existence.
+
+.SH DESCRIPTION
+.LP
+The
+\fBlzc_exists\fR()
+function tests whether
+.I dataset
+exists. It is more efficient than calling
+\fBlzc_list\fR(),
+but it does not apply to bookmarks.
+
+.SH RETURN VALUES
+.sp
+.LP
+On success, the
+\fBlzc_exists\fR()
+function returns a 0 (B_TRUE) when
+.I dataset
+exists and 1 (B_FALSE) when
+.I dataset
+does not exist. On failure, the function returns an error code.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_exists()\fR function should never return an error when the library
+has been properly initialized.
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_list\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_get_bookmarks.3
+++ b/man/man3/lzc_get_bookmarks.3
@@ -1,0 +1,166 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_get_boomarks 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual. The location of
+the header might vary on different systems.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_get_bookmarks\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIprops\fR, \fBnvlist_t **\fR\fIbmarks\fR);
+
+.SH NAME
+lzc_get_bookmarks \- Retrieve bookmarks of a given filesystem
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_get_bookmarks\fR() function will retrieve the list of bookmarks for
+the given file system. The \fIprops\fR parameter is an nvlist of property names
+(with no values) that will be returned for each bookmark. The \fIbmarks\fR
+parameter is a pointer to a nvlist of the bookmarks. The caller is responsible
+for freeing it with \fBnvlist_free\fR().
+
+The format of the returned nvlist as follows:
+.P
+<short name of bookmark> -> {
+    <name of property> -> {
+        "value" -> uint64
+     }
+.br
+}
+
+The following are valid properties on bookmarks. All of them are uint64 values
+in the nvlist:
+.sp
+.na
+\fB\fBguid\fR\fR
+.ad
+.RS
+Globally unique identifier of the referenced snapshot
+.RE
+
+.na
+\fB\fBcreatetxg\fR\fR
+.ad
+.RS
+Number of transaction group (txg) when the snapshot provided to the bookmark was created
+.RE
+
+.na
+\fB\fBcreation\fR\fR
+.RS
+UNIX timestamp when the snapshot used to make the bookmark was created
+.RE
+
+.sp
+Unsupported properties will be silently ignored.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_inherit()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is invalid.
+.sp
+The nvlist \fIprops\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR exceeds 255 characters (excluding NULL
+termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIprops\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBESRCH\fR\fR
+.ad
+.RS 13n
+A specified, but valid, bookmark was not found. This merits a bug report.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_get_holds.3
+++ b/man/man3/lzc_get_holds.3
@@ -1,0 +1,130 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_get_holds 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_get_holds\fR(\fBconst char *\fR\fIsnapname\fR, \fBnvlist_t **\fR\fIholdsp\fR);
+
+.SH NAME
+lzc_get_holds \- Retrieve list of user holds on the specified snapshot.
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_get_holds\fR() function returns a nvlist of holds on the snapshot.
+The nvlist keys will be the short names of the holds while the nvlist values
+will be uint64 numbers.  The numbers are internal identifiers that have no
+application to userland in the current iteration of the libzfs_core API.
+
+.SH RETURN VALUE
+On success, the \fBlzc_get_holds\fR() function returns 0 and fills in
+\fI*holdsp\fR when \fIholdsp\R is non-NULL. On failure, the function returns an
+error code.
+
+.SH ERRORS
+.BR lzc_get_holds ()
+can fail with the following errors:
+
+.TP
+.B ENOENT
+Pool does not exist, or if unintialized, the cachefile is out of
+sync because loading the pool failed due to an exported or
+destroyed pool.  If pool exists, snapshot does not exist.
+.TP
+.B EEXIST
+The pool was uninitialized and a pool with the same GUID already
+existed.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_inherit()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The snapshot name \fIsnapname\fR is not syntactically correct.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or
+destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was
+read from the cachefile.
+.sp
+The snapshot \fIsnapname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_hold\fR(3), \fBlzc_release\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_hold.3
+++ b/man/man3/lzc_hold.3
@@ -1,0 +1,183 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_hold 7 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_hold\fR(\fBnvlist_t *\fR\fIholds\fR, \fBint\fR \fIcleanup_fd\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+.sp
+\fBint\fR \fBlzc_release\fR(\fBnvlist_t *\fR\fIholds\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+
+
+.SH NAME
+lzc_hold, lzc_release \- Creates and releases user holds on snapshots
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_hold\fR() function creates user holds on snapshots. If there is a
+hold on a snapshot, the snapshot can not be destroyed.
+.sp
+However, it can be marked for deletion by calling \fBlzc_destroy_snaps\fR()
+with defer=B_TRUE. Snapshots preserved in the way shall be destroyed as the
+user hold is removed.
+.sp
+\fBlzc_release\fR() shall explicitly release a hold. If the snapshot has been
+marked for deferred destroy by calling \fBlzc_destroy_snaps\fR() with
+defer=B_TRUE, it does not have any clones, and all the user holds are removed,
+then the snapshot shall be destroyed.
+
+.I snaps
+shall be a nvlist with zfs snapshots to hold to hold. It shall store string
+keys that are the snapshots and values that are the hold names.
+
+.I cleanup_fd
+shall be a file descriptor that specifies thta the hold is temporary and is to
+be closed when the specified file descriptor is closed. Specifying the file
+descriptor 0 disables this behavior while specifying the file descriptor -1
+shall make the hold close when the file descriptor for /dev/zfs held by the
+library is closed.
+
+.I errlist
+shall contain a handle that shall be used to store a pointer to a library
+allocated nvlist when non-NULL and the operation for at least one hold fails.
+The names of the holds shall be the keys while the values shall contain the
+error codes and be of type int32.  Holds that failed to release because they
+did not exist shall also have an entry added. It shall not be touched
+otherwise.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_hold()\fR function shall fail if:
+.sp
+.ne 2
+.na
+\fB\fBE2BIG\fR\fR
+.ad
+.RS 13n
+The hold short name exceeds 256 or 238 in the case of a temporary
+hold.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEBADF\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIcleanup_fd\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+A hold with a name specified in \fIsnaps\fR already exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The nvlist \fIsnaps\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+A snapshot or hold name specified in \fIsnaps\fR nvlist exceeds 255 characters
+(excluding NULL termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+A snapshot specified in \fIsnaps\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIsnaps\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+Called on a pool that is earlier than version 18.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_get_holds\fR(3), \fBlzc_destroy_holds\fR(3),
+\fBzfs\fR(8)

--- a/man/man3/lzc_inherit.3
+++ b/man/man3/lzc_inherit.3
@@ -1,0 +1,146 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_inherit 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_inherit\fR(\fBconst char *\fR\fIfsname\fR, \fBconst char *\fR\fIpropname\fR, \fBnvlist_t *\fR\fIopts\fR);
+
+.SH NAME
+lzc_inherit \- Reset dataset property to default value
+
+.SH DESCRIPTION
+.LP
+The
+\fBlzc_inherit\fR()
+function shall atomically reset property \fIpropname\fR of dataset
+\fIfsname\fR.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_inherit()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is invalid.
+.sp
+The property name \fIpropname\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIpropname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIopts\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOSPC\fR\fR
+.ad
+.RS 13n
+Not enough space to update property.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+Called \fBlzc_inherit()\fR for \fIpropname\fR property on a pool those version predates its introduction.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEROFS\fR\fR
+.ad
+.RS 13n
+Attempted to inherit volsize on readonly zvol.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_list.3
+++ b/man/man3/lzc_list.3
@@ -1,0 +1,375 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_list 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_list\fR(\fBconst char *\fR\fIname\fR, \fBnvlist_t
+*\fR\fIopts\fR)
+
+.SH NAME
+lzc_list \- List filesystems, volumes, snapshots and bookmarks
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_list\fR() function writes a series of records to the output method
+specified in the nvlist \fIopts\fR. It is designed to provide a large subset of
+the functionality of the \fBzfs list\fR subcommand and operates similarly to
+it. At present, the only supported output method is an asynchronous file
+descriptor.
+
+.I name
+The name of the pool, dataset, snapshot or volume to list by writing to fd. If
+NULL, a description of all pools is written to fd.
+
+.I opts
+A nvlist used to manipulate output. It takes these values:
+.sp
+.in +2
+.nf
+NAME                    TYPE                    DESCRIPTION
+"fd"                    int32                   UNIX file descriptor for output.
+"recurse"               boolean/uint64          List output for children.
+"type"                  nvlist                  List only types specified.
+.fi
+.in -2
+.sp
+At present, the fd field is the only supported output method and therefore, it
+is mandatory. If the name field is a bookmark or snapshot, the recurse field
+is ignored.  If the passed name is that of a bookmark or snapshot, the recurse
+field is ignored. If all children are desired, recurse should be set to be a
+boolean type. If a recursion limit is desired, recurses hould be a uint64_t. If
+no type is specified, a default behavior consistent with the zfs list command
+is provided. Valid children of the type nvlist are:
+.sp
+.in +2
+.nf
+NAME                    TYPE                    DESCRIPTION
+"all"                   boolean                 List output for all types
+"bookmark"              boolean                 List output for bookmarks
+"filesystem"            boolean                 List output for filesystems
+"snap"                  boolean                 List output for snapshots
+"snapshot"              boolean                 List output for snapshots
+"volume"                boolean                 List output for volumes
+.fi
+.in -2
+.sp
+Whenever a boolean type is specified, any type may be passed and be
+considered boolean. However, future extensions may accept alternate types
+and consequently, backward compatibility is only guarenteed to callers
+passing a boolean type that contains no value. A boolean that contains
+B_TRUE or B_FALSE is considered a separate type from a boolean that contains
+no value. Additionally, future enhancements to zfs may create a new type and
+callers that only wish to handle existing types should specify them
+explicitly rather than relying on the default behavior.
+.sp
+The parent-child relationship is obeyed such all children of each
+pool/directory are output alongside their parents. However, no guarantees
+are made with regard to post-order/pre-order traversal or the order of
+bookmarks/snapshots, such that the order is allowed to change. Userland
+applications that are sensitive to a particular output order are expected to
+sort.
+.sp
+The output consists of a record header followed immediately by XDR-encoded
+nvlist. The header format is as follows:
+.sp
+.in +2
+.nf
+OFFSET                  SIZE                    DESCRIPTION
+0 bytes                 4 bytes                 XDR-nvlist size (unsigned)
+4 bytes                 1 byte                  Header extension space (unsigned)
+5 bytes                 1 byte                  Return code (unsigned)
+6 bytes                 1 byte                  Endian bit (0 is BE, 1 is LE)
+7 bytes                 1 byte                  Reserved
+.fi
+.in -2
+.sp
+Errors obtaining information for any record will be contained in the return
+code. The output for any record whose header return code contains an error
+is a XDR encoded nvlist whose contents are undefined, unless the size
+provided in the header is zero, in which case the output for that record is
+empty. The receiver is expected to check the endian bit field before
+processing the XDR-nvlist size and perform a byte-swap operation on the
+value should the endian-ness differ.
+.sp
+Non-zero values in the reserved field and upper bits of the endian field
+imply a back-incompatible change. If the header extension field is non-zero
+when neither the reserved field nor the upper bits of the endian field are
+non-zero, the header should be assumed to have been extended in a
+backward-compatible way and the XDR-nvlist of the specified size shall
+follow the extended header. The lzc_list() library call will always request
+API version 0 request as part of the ioctl to userland.  Consequently, the
+kernel will return an API version 0 compatible-stream unless a change is
+requested via a future extension to the opts nvlist.
+.sp
+The nvlist will have the following members:
+.sp
+.in +2
+.nf
+NAME                    TYPE                    DESCRIPTION
+"name"                  string                  SPA/DSL name
+"dmu_objset_stats"      nvlist                  DMU Objset Stats
+"properties"            nvlist                  DSL properties
+.fi
+.in -2
+.sp
+Additional members may be added in future extensions.
+.sp
+The "dmu_objset_stats" will have the following members:
+.sp
+.in +2
+.nf
+NAME                    TYPE            DESCRIPTION
+"dds_num_clones"        uint64_t        Number of clones
+"dds_creation_txg"      uint64_t        Creation transaction group
+"dds_guid"              uint64_t        Globally unique identifier
+"dds_type"              string          Type
+"dds_is_snapshot"       boolean         Is a snapshot
+"dds_inconsistent"      boolean         Is being received or destroyed
+"dds_origin"            string          Name of parent
+.fi
+.in -2
+.sp
+Additional members may be added in future extensions.
+.sp
+The "dds_" prefix stands for "DSL Dataset". "dds_type" is a string
+representation of internal object types. Valid values at this time are:
+.sp
+.in +2
+.nf
+NAME                    PUBLIC          DESCRIPTION
+"NONE"                  No              Uninitialized value
+"META"                  No              Metadata
+"ZPL"                   Yes             Dataset
+"ZVOL"                  Yes             Volume
+"OTHER"                 No              Undefined
+"ANY"                   No              Open
+.fi
+.in -2
+.sp
+Only the public values will be returned for any output. The return of a
+value not on this list implies a record for a new storage type. The output
+should be consistent with existing types and the receiver can elect to
+either handle it in a manner consistent with existing types or skip it.
+Under no circumstance will an unlisted type be returned when types were
+explicitly provided via the opts nvlist.
+.sp
+On bookmarks, the "dmu_objset_stats" of the parent DSL Dataset shall be
+returned. Consequently, "dds_is_snapshot" shall be false and identification
+of bookmarks shall be done by checking for the '#' character in the "name"
+member of the top level nvlist. This is done so that the type of the
+bookmarked DSL dataset may be known.
+.sp
+End of output shall be signified by NULL record header. Userland is expected
+to close the file descriptor. Early termination can be signaled from
+userland by closing the file descriptor.
+.sp
+The design of the output is intended to enable userland to perform readahead
+on the file descriptor. On certain platforms, libc may provide output
+buffering. Userland libraries and applications electing to perform readahead
+should take care not to block on a partially filled buffer when an end of
+stream NULL record is returned.
+.sp
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_list()\fR function shall fail if:
+.sp
+.ne 2
+.na
+\fB\fBEAGAIN\fR\fR, \fB\fBEWOULDBLOCK\fR\fR
+.ad
+.RS 13n
+The file descriptor was marked non-blocking and the call would block. This is
+from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEBADE\fR\fR
+.ad
+.RS 13n
+An uncorrectable checksum failure was encountered.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEBADF\fR\fR
+.ad
+.RS 13n
+The file descriptor "\fIfd\fR" in the \fIopts\fR nvlist is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEDESTADDRREQ\fR\fR
+.ad
+.RS 13n
+The file descriptor is a datagram socket for which a peer address has not been
+set using \fBconnect\fR(2).  This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEFAULT\fR\fR
+.ad
+.RS 13n
+Internal issue occurred when copying command data from userland to kernel. See
+Illumos ddi_copyin(9F).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEFBIG\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR in the \fIopts\fR nvlist is a file and writing to
+it would cause it to exceed the maximum file size permitted by the filesystem.
+This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEIO\fR\fR
+.ad
+.RS 13n
+A low level error occurred. This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The string \fIname\fR is not a valid pool, dataset, volume, snapshot or bookmark name.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+Nothing named \fIname\fR exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIopts\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOSPC\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR in the \fIopts\fR nvlist cannot be appended. This
+is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPIPE\fR\fR
+.ad
+.RS 13n
+The file descriptor is a pipe whose reading end is closed. This is from
+\fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH ERRATA
+Unlike other \fBlzc_*\fR() functions, the output of this function is non-atomic.
+Consequently, rename, creation, destruction and property creation operations
+can race with it. Avoiding this requires allowing userland to block the kernel
+when it holds key locks required for the aforementioned operations, which is a
+denial of service vulnerability. Userland consumers must handle edge cases
+where concurrent operations cause the output to be inconsistent. One example is
+that renames can cause datasets to appear twice (or not at all) depending on
+what has been output and where the rename moves a dataset, volume, snapshot or
+bookmark.
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_promote.3
+++ b/man/man3/lzc_promote.3
@@ -1,0 +1,140 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_promote 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_promote\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIopts\fR);
+
+.SH NAME
+lzc_promote \- Reverse clone parent-child relationship
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_promote\fR() function promotes a clone file system \fIfsname\fR to
+no longer be dependent on its "origin" snapshot. This makes it possible to
+destroy the file system from which the clone was created. The clone
+parent-child dependency relationship is reversed, so that the origin file
+system becomes a clone of the specified file system.
+
+The snapshot that was cloned, and any snapshots previous to this snapshot, are
+now owned by the promoted clone. The space they use moves from the origin file
+system to the promoted clone, so enough space must be available to accom‐
+modate these snapshots. No new space is consumed by this operation, but the
+space accounting is adjusted. The promoted clone must not have any conflicting
+snapshot names of its own. The rename subcommand can be used to rename  any
+conflicting snapshots.
+
+The nvlist \fIopts\fR is reserved for future extensions that provide options
+that alter the behavior of the lzc_promote() function. At the time of writing,
+all data passed to it is ignored and callers should pass NULL to ensure that
+behavior remains the same with future extensions.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_promote()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIfsname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIopts\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The clone \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOSPC\fR\fR
+.ad
+.RS 13n
+Not enough space to update property.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_receive.3
+++ b/man/man3/lzc_receive.3
@@ -1,0 +1,204 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_receive 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_receive\fR(\fBconst char *\fR\fIsnapname\fR, \fBnvlist_t
+*\fR\fIprops\fR, \fBconst char *\fR\fIorigin\fR, \fBboolean_t\fR \fIforce\fR,
+\fBint\fR \fIfd\fR);
+
+.SH NAME
+lzc_receive \- Create a snapshot from a zfs send stream
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_receive\fR() function reads a zfs send stream from the file
+descriptor \fIfd\fR to atomically create the snapshot \fIsnapname\fR. Any
+properties specified by \fIprops\fR shall be set as received properties.
+
+If the stream is a clone, its origin snapshot must be specified by \fIorigin\fR.
+The \fIforce\fR flag will cause the target filesystem to be rolled back or
+destroyed if necessary to receive the send stream.
+
+This interface does not work on deduplicated streams (those with
+DMU_BACKUP_FEATURE_DEDUP) at this time. Also, O_NONBLOCK is not supported on
+\fIfd\fR.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_receive()\fR function shall fail if:
+.sp
+.ne 2
+.na
+\fB\fBEAGAIN\fR\fR, \fB\fBEWOULDBLOCK\fR\fR
+.ad
+.RS 13n
+The file descriptor was marked non-blocking and the call would block. This is
+from \fBread\fR(2). This indicates a userland programming bug because \fIfd\fB
+should never be set as being non-blocking.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEBADE\fR\fR
+.ad
+.RS 13n
+Checksum failure in stream.
+.RE
+
+
+.sp
+.ne 2
+.na
+\fB\fBEBADF\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEFAULT\fR\fR
+.ad
+.RS 13n
+Internal issue occurred when copying command data from userland to kernel. See
+Illumos ddi_copyin(9F).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEIO\fR\fR
+.ad
+.RS 13n
+Reading the dmu replay record header from the file descriptor failed.
+.sp
+A low level error occurred. This is from \fBread\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINTR\fR\fR
+.ad
+.RS 13n
+The call was interrupted by a userspace signal.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR is not a valid bookmark or snapshot name.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEISDIR\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR belongs to a directory. This is from \fBread\fR(2).
+.RE
+
+:sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The snapshot or bookmark named \fIsnapname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIparams\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH BUGS
+File descriptors with O_NONBLOCK do not fail immediately.
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_hold\fR(3), \fBlzc_receive\fR(3), \fBwrite\fR(2),
+\fBzfs\fR(8)

--- a/man/man3/lzc_release.3
+++ b/man/man3/lzc_release.3
@@ -1,0 +1,1 @@
+.so man3/lzc_hold.3

--- a/man/man3/lzc_rollback.3
+++ b/man/man3/lzc_rollback.3
@@ -1,0 +1,144 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_rollback 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_rollback\fR(\fBconst char *\fR\fIfsname\fR, \fBchar *\fR\fIsnapnamebuf\fR, \fBint\fR \fIsnapnamelen\fR);
+
+.SH NAME
+lzc_rollback \- Rollback this filesystem or volume to its most recent snapshot. 
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_rollback\fR() function rolls back a live dataset or volume to its most recent snapshot.
+
+.I fsname
+shall be the name of the most recent snapshot to rollback.
+
+.I snapnamebuf
+shall be a pointer to a string to fill with the name of the most recent
+snapshot. If NULL, it wll be ignored.
+
+.I snapnamelen
+shall be the length of \fIsnapnamebuf\fR.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned and \fIsnapnamebuf\fR is filled if
+non-NULL. Otherwise, an error is returned.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_rollback()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEBUSY\fR\fR
+.ad
+.RS 13n
+The dataset has a hold.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEDQUOT\fR\fR
+.ad
+.RS 13n
+The snapshot uses more data than th file system quota.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+\fIfsname\fR must be the most recent snapshot.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIfsname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+A dataset or volume specified in \fIsnaps\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOSPC\fR\fR
+.ad
+.RS 13n
+Not enough space to rollback snapshot.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+.
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_snapshot\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_send.3
+++ b/man/man3/lzc_send.3
@@ -1,0 +1,227 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_send 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_send\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char
+*\fR\fIfrom\fR, \fBint\fR \fIfd\fR, \fBenum lzc_send_flags\fR \fIflags);
+.sp
+\fBint\fR \fBlzc_send_ext\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char
+*\fR\fIfrom\fR, \fBint\fR \fIfd\fR, \fBnvlist_t *\fR\fIparams\fR);
+
+.SH NAME
+lzc_send, lzc_send_ext \- Generate a send stream from a snapshot
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_send\fR() and \fBlzc_send_ext\fR() functions write a ZFS stream to
+file descriptor \fIfd\fR from snapshot \fIsnapname\fR of dataset \fIfrom\fR.
+The only difference between the two functions is that one uses a bitmask called
+\fIflags\fR for passing flags while the other uses a nvlist called \fIparams\fR
+for passing flags.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_send()\fR and \fBlzc_send_ext()\fR functions shall fail if:
+.sp
+.ne 2
+.na
+\fB\fBEAGAIN\fR\fR, \fB\fBEWOULDBLOCK\fR\fR
+.ad
+.RS 13n
+The file descriptor was marked non-blocking and the call would block. This is
+from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEBADF\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEDESTADDRREQ\fR\fR
+.ad
+.RS 13n
+The file descriptor is a datagram socket for which a peer address has not been
+set using \fBconnect\fR(2).  This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEFAULT\fR\fR
+.ad
+.RS 13n
+Internal issue occurred when copying command data from userland to kernel. See
+Illumos ddi_copyin(9F).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEFBIG\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR is a file and writing to it would cause it to
+exceed the maximum file size permitted by the filesystem. This is from
+\fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEIO\fR\fR
+.ad
+.RS 13n
+A low level error occurred. This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINTR\fR\fR
+.ad
+.RS 13n
+The call was interrupted by a userspace signal.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR is not a valid bookmark or snapshot name.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The snapshot or bookmark named \fIsnapname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIparams\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOSPC\fR\fR
+.ad
+.RS 13n
+The file descriptor \fIfd\fR cannot be appended. This is from \fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPIPE\fR\fR
+.ad
+.RS 13n
+The file descriptor is a pipe whose reading end is closed. This is from
+\fBwrite\fR(2).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBESRCH\fR\fR
+.ad
+.RS 13n
+A specified, but valid, bookmark was not found. This merits a bug report.
+.RE
+
+.SH BUGS
+File descriptors with O_NONBLOCK do not fail immediately.
+
+.SH SEE ALSO
+.sp
+.LP
+\fBconnect\fR(2) \fBlibzfs_core.h\fR(3), \fBlzc_hold\fR(3),
+\fBlzc_receive\fR(3), \fBwrite\fR(2), \fBzfs\fR(8)

--- a/man/man3/lzc_send_ext.3
+++ b/man/man3/lzc_send_ext.3
@@ -1,0 +1,1 @@
+.so man3/lzc_send.3

--- a/man/man3/lzc_send_progress.3
+++ b/man/man3/lzc_send_progress.3
@@ -1,0 +1,112 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_send_progress 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_send_progress\fR(\fBconst char *\fR\fIsnapname\fR, \fBint\fR \fIfd\fR, \fBuint64_t *\fR\fIbytesp\fR);
+
+.SH NAME
+lzc_send_progress \- Query bytes written to fd by active send stream
+
+.SH DESCRIPTION
+.LP
+The
+\fBlzc_send_progress\fR()
+function returns how many bytes have been written by send stream to \fIfd\fR.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned and \fI*bytesp\fR is updated.
+Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_send_progress()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The snapshot name \fIsnapname\fR is not syntactically correct.
+.RE
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loadng unitialized pool from cachefile failed because the pool was exported or
+destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was
+read from the cachefile.
+.sp
+The snapshot \fIsnapname\fR does not exist.
+.sp
+No active send stream was found that maches \fIfd\fR and \fIsnapname\fR
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_send\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_send_space.3
+++ b/man/man3/lzc_send_space.3
@@ -1,0 +1,129 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_send_space 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_send_space\fR(\fBconst char *\fR\fIsnapname\fR, \fBconst char *\fR\fIfrom\fR, \fBuint64_t *\fR\fIspacep\fR);
+
+.SH NAME
+lzc_send_space\- Calculates approximately how many bytes would be written by
+lzc_send()/lzc_send_ext().
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_send_space\fR() function calculates approximately how many bytes
+would be written by lzc_send()/lzc_send_ext().
+
+If \fIfrom\fR is NULL, the space for a non-incremental stream is calculated.
+Calculations for deduplicated streams are not supported.
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned and \fI*spacep\fR is updated.
+Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_send_space()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The snapshot name \fIsnapname\fR is not syntactically correct.
+.sp
+The snapshot name \fIfrom\fR is not syntactically correct.
+.RE
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIsnapname\fR exceeds 255 characters (excluding NULL termination
+character).
+.sp
+The string \fIfrom\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loadng unitialized pool from cachefile failed because the pool was exported or
+destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was
+read from the cachefile.
+.sp
+The snapshot \fIsnapname\fR does not exist.
+.sp
+The snapshot \fIfrom\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+The snapshot \fIfrom\fR is not an earlier snapshot than the snapshot \fIsnapname\fR.
+.sp
+The snapshot \fIfrom\fR and the snapshot \fIsnapname\fR are not snapshots of the same dataset. Alternatively, they are not of the same pool.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBlzc_send\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_set_props.3
+++ b/man/man3/lzc_set_props.3
@@ -1,0 +1,176 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_set_props 3 "2015 JUL 7" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_set_props\fR(\fBconst char *\fR\fIfsname\fR, \fBnvlist_t *\fR\fIprops\fR, \fBboolean_t\fR \fIreceived\fR);
+
+.SH NAME
+lzc_set_props \- Set properties on a dataset or volume
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_set_props\fR() function will set properties on a given dataset or volume.
+.sp
+.I fsname
+is a string containing the name of a dataset or filesystem.
+.sp
+.I props
+is a nvlist containing the properties to set. See \fBzfs\fR(8) for descriptions
+of properties.
+.sp
+.I opts
+is a nvlist containing additional options to pass to this command. Currently, the only option is the boolean property "received", which is to specify that the properties being set were received from a send stream. 
+
+The \fIprops\fR parameter is an nvlist of property names
+(with no values) that will be returned for each bookmark. The \fIbmarks\fR
+parameter is a pointer to a nvlist of the bookmarks. The caller is responsible
+for freeing it with \fBnvlist_free\fR().
+
+The format of the returned nvlist as follows:
+.P
+<short name of bookmark> -> {
+    <name of property> -> {
+        "value" -> uint64
+     }
+.br
+}
+
+The following are valid properties on bookmarks. All of them are uint64 values
+in the nvlist:
+.sp
+.na
+\fB\fBguid\fR\fR
+.ad
+.RS
+Globally unique identifier of the referenced snapshot
+.RE
+
+.na
+\fB\fBcreatetxg\fR\fR
+.ad
+.RS
+Number of transaction group (txg) when the snapshot provided to the bookmark was created
+.RE
+
+.na
+\fB\fBcreation\fR\fR
+.RS
+UNIX timestamp when the snapshot used to make the bookmark was created
+.RE
+
+.sp
+Unsupported properties will be silently ignored.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned and all properties have been set. Otherwise, an error is returned.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_inherit()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR is invalid.
+.sp
+The nvlist \fIprops\fR is invalid.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The dataset name \fIfsname\fR exceeds 255 characters (excluding NULL
+termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+The dataset \fIfsname\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIprops\fR to the kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBESRCH\fR\fR
+.ad
+.RS 13n
+A specified, but valid, bookmark was not found. This merits a bug report.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_snaprange_space.3
+++ b/man/man3/lzc_snaprange_space.3
@@ -1,0 +1,135 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_snaprange_space 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_snaprange_space\fR(\fBconst char *\fR\fIfirstsnap\fR, \fBconst char *\fR\fIlastsnap\fR, \fBuint64_t *\fR\fIusedp\fR);
+
+.SH NAME
+lzc_snaprange_space \- Determine how much space is used by a snapshot range.
+
+.SH DESCRIPTION
+.LP
+The
+\fBlzc_snaprange_space\fR()
+function calculates how much space in bytes the differences between
+\fIfirstsnap\fR and \fIlastsnap\fR use in the pool. They must be snapshots of
+the same dataset.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_snaprange_space()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+A dataset named \fIfsname\fR already exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+The snapshot name \fIfirstsnap\fR is not syntactically correct.
+.sp
+The snapshot name \fIlastsnap\fR is not syntactically correct.
+.RE
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+The string \fIfirstsnap\fR exceeds 255 characters (excluding NULL termination
+character).
+.sp
+The string \fIlastsnap\fR exceeds 255 characters (excluding NULL termination
+character).
+.RE
+
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loadng unitialized pool from cachefile failed because the pool was exported or
+destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was
+read from the cachefile.
+.sp
+The snapshot \fIfirstsnap\fR does not exist.
+.sp
+The snapshot \fIlastsnap\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+\fIfirstsnap\fR must be an earlier snapshot than \fIlastsnap\fR.
+.sp
+\fIfirstsnap\fR and \fIlastsnap\fR are not from the same dataset.
+.RE
+
+.SH BUGS
+.LP
+Early implementations of the API will return \fB\fBENOENT\fR\fR instead of
+\fB\fBEXDEV\fR\fR. The same implementations would also segfault in
+\fBlzc_snaprange_space()\fR when \fI*usedp\fR was NULL. These issues were
+rectified when the man page was written. 
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/man/man3/lzc_snapshot.3
+++ b/man/man3/lzc_snapshot.3
@@ -1,0 +1,176 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2015 ClusterHQ Inc. All rights reserved.
+.\"
+.TH lzc_snapshot 3 "2015 JUL 8" "OpenZFS" "OpenZFS Programmer's Manual"
+
+.SH PROLOG
+This manual page is part of the OpenZFS Programmer's Manual.
+
+.SH SYNOPSIS
+#include <libzfs_core.h>
+
+\fBint\fR \fBlzc_snapshot\fR(\fBnvlist_t *\fR\fIsnaps\fR, \fBnvlist_t
+*\fR\fIprops\fR, \fBnvlist_t **\fR\fIerrlist\fR);
+
+.SH NAME
+lzc_snapshot \- Creates a snapshot of a dataset or volume
+
+.SH DESCRIPTION
+.LP
+The \fBlzc_snapshot\fR() function creates atomic snapshots of all ZFS
+datasets and/or volumes named in the \fIsnaps\fR nvlist.
+
+.I snaps
+shall be a nvlist containing strings that specify the snapshots to create. All snapshot smust be inside the same pool.
+
+.I props
+shall either be NULL or contain a nvlist with properties to set on the snapshot
+at creation time. Currently only user properties are supported. It shall be of
+the format:
+.sp
+{ user:prop_name -> string value }
+
+.I errlist
+shall contain a handle that shall be used to store a pointer to a library
+allocated nvlist when non-NULL and the operation for at least one hold fails.
+The names of the holds shall be the keys while the values shall contain the
+error codes and be of type int32. Holds that failed to release because they did
+not exist shall also have an entry added. It shall not be touched otherwise.
+
+.SH RETURN VALUES
+.sp
+.LP
+Upon successful completion, 0 is returned. Otherwise, an error is returned.
+.sp
+On error, an error is returned from one of the holds where an error occurred
+and \fI*errlist\fR is initialized with a pointer to a nvlist with more specific
+information when \fIerrlist\fR is non-NULL. The caller must call
+\fBnvlist_free\fR(\fI*errlist\fR) when this occurs.
+
+.SH ERRORS
+.sp
+.LP
+The \fBlzc_snapshot()\fR function will fail if:
+.sp
+.ne 2
+.na
+\fB\fBE2BIG\fR\fR
+.ad
+.RS 13n
+The length of a property value is larger than 8191 characters excluding the
+NULL termination character.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEEXIST\fR\fR
+.ad
+.RS 13n
+The pool was uninitialized and a pool with the same GUID already existed.
+.sp
+A snapshot with a name specified in \fIsnaps\fR already exists.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEINVAL\fR\fR
+.ad
+.RS 13n
+A property name in the \fIprops\fR nvlist is invalid.
+.sp
+\fIsnaps\fR is not a valid nvlist.
+.sp
+\fIprops\fR is not a valid nvlist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENAMETOOLONG\fR\fR
+.ad
+.RS 13n
+A snapshot name in the \fIsnaps\fR nvlist exceeds 255 characters (excluding
+NULL termination character).
+.sp
+A property name in \fIprops\fR nvlist exceeds 255 characters (excluding NULL
+termination character).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOENT\fR\fR
+.ad
+.RS 13n
+Pool does not exist.
+.sp
+Loading unitialized pool from cachefile failed because the pool was exported or destroyed.
+.sp
+Internal error where uninitialized pool lacks a GUID in its config that was read from the cachefile.
+.sp
+A dataset or volume specified in \fIsnaps\fR does not exist.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOMEM\fR\fR
+.ad
+.RS 13n
+Failed to allocate memory necessary to send \fIsnaps\fR or \fIprops\fR to the
+kernel.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBENOTSUP\fR\fR
+.ad
+.RS 13n
+User properties were specified on a pool that is newer than version 12.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBEPERM\fR\fR
+.ad
+.RS 13n
+Permission denied by zone security policy.
+.RE
+
+\fB\fBEXDEV\fR\fR
+.ad
+.RS 13n
+Multiple pools specified
+.sp
+Multiple snapshots per filesystem specified.
+.RE
+
+.SH SEE ALSO
+.sp
+.LP
+\fBlibzfs_core.h\fR(3), \fBzfs\fR(8)

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -221,237 +221,237 @@ zfs_prop_init(void)
 	    ZFS_REDUNDANT_METADATA_ALL,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "all | most", "REDUND_MD",
-	    redundant_metadata_table);
+	    redundant_metadata_table, NULL);
 	zprop_register_index(ZFS_PROP_SYNC, "sync", ZFS_SYNC_STANDARD,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "standard | always | disabled", "SYNC",
-	    sync_table);
+	    sync_table, NULL);
 	zprop_register_index(ZFS_PROP_CHECKSUM, "checksum",
 	    ZIO_CHECKSUM_DEFAULT, PROP_INHERIT, ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_VOLUME,
 	    "on | off | fletcher2 | fletcher4 | sha256", "CHECKSUM",
-	    checksum_table);
+	    checksum_table, NULL);
 	zprop_register_index(ZFS_PROP_DEDUP, "dedup", ZIO_CHECKSUM_OFF,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "on | off | verify | sha256[,verify]", "DEDUP",
-	    dedup_table);
+	    dedup_table, NULL);
 	zprop_register_index(ZFS_PROP_COMPRESSION, "compression",
 	    ZIO_COMPRESS_DEFAULT, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4", "COMPRESS",
-	    compress_table);
+	    compress_table, NULL);
 	zprop_register_index(ZFS_PROP_SNAPDIR, "snapdir", ZFS_SNAPDIR_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
-	    "hidden | visible", "SNAPDIR", snapdir_table);
+	    "hidden | visible", "SNAPDIR", snapdir_table, NULL);
 	zprop_register_index(ZFS_PROP_SNAPDEV, "snapdev", ZFS_SNAPDEV_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "hidden | visible", "SNAPDEV", snapdev_table);
+	    "hidden | visible", "SNAPDEV", snapdev_table, NULL);
 	zprop_register_index(ZFS_PROP_ACLTYPE, "acltype", ZFS_ACLTYPE_OFF,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
-	    "noacl | posixacl", "ACLTYPE", acltype_table);
+	    "noacl | posixacl", "ACLTYPE", acltype_table, NULL);
 	zprop_register_index(ZFS_PROP_ACLINHERIT, "aclinherit",
 	    ZFS_ACL_RESTRICTED, PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
 	    "discard | noallow | restricted | passthrough | passthrough-x",
-	    "ACLINHERIT", acl_inherit_table);
+	    "ACLINHERIT", acl_inherit_table, NULL);
 	zprop_register_index(ZFS_PROP_COPIES, "copies", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "1 | 2 | 3", "COPIES", copies_table);
+	    "1 | 2 | 3", "COPIES", copies_table, NULL);
 	zprop_register_index(ZFS_PROP_PRIMARYCACHE, "primarycache",
 	    ZFS_CACHE_ALL, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT | ZFS_TYPE_VOLUME,
-	    "all | none | metadata", "PRIMARYCACHE", cache_table);
+	    "all | none | metadata", "PRIMARYCACHE", cache_table, NULL);
 	zprop_register_index(ZFS_PROP_SECONDARYCACHE, "secondarycache",
 	    ZFS_CACHE_ALL, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT | ZFS_TYPE_VOLUME,
-	    "all | none | metadata", "SECONDARYCACHE", cache_table);
+	    "all | none | metadata", "SECONDARYCACHE", cache_table, NULL);
 	zprop_register_index(ZFS_PROP_LOGBIAS, "logbias", ZFS_LOGBIAS_LATENCY,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "latency | throughput", "LOGBIAS", logbias_table);
+	    "latency | throughput", "LOGBIAS", logbias_table, NULL);
 	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_DIR,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
-	    "on | off | dir | sa", "XATTR", xattr_table);
+	    "on | off | dir | sa", "XATTR", xattr_table, NULL);
 
 	/* inherit index (boolean) properties */
 	zprop_register_index(ZFS_PROP_ATIME, "atime", 1, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "on | off", "ATIME", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "on | off", "ATIME", boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_RELATIME, "relatime", 0, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "on | off", "RELATIME", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "on | off", "RELATIME", boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_DEVICES, "devices", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT, "on | off", "DEVICES",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_EXEC, "exec", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT, "on | off", "EXEC",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_SETUID, "setuid", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT, "on | off", "SETUID",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_READONLY, "readonly", 0, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "on | off", "RDONLY",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_ZONED, "zoned", 0, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "on | off", "ZONED", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "on | off", "ZONED", boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_VSCAN, "vscan", 0, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "on | off", "VSCAN", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "on | off", "VSCAN", boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_NBMAND, "nbmand", 0, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT, "on | off", "NBMAND",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_OVERLAY, "overlay", 0, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "on | off", "OVERLAY", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "on | off", "OVERLAY", boolean_table, NULL);
 
 	/* default index properties */
 	zprop_register_index(ZFS_PROP_VERSION, "version", 0, PROP_DEFAULT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
-	    "1 | 2 | 3 | 4 | 5 | current", "VERSION", version_table);
+	    "1 | 2 | 3 | 4 | 5 | current", "VERSION", version_table, NULL);
 	zprop_register_index(ZFS_PROP_CANMOUNT, "canmount", ZFS_CANMOUNT_ON,
 	    PROP_DEFAULT, ZFS_TYPE_FILESYSTEM, "on | off | noauto",
-	    "CANMOUNT", canmount_table);
+	    "CANMOUNT", canmount_table, NULL);
 
 	/* readonly index (boolean) properties */
 	zprop_register_index(ZFS_PROP_MOUNTED, "mounted", 0, PROP_READONLY,
-	    ZFS_TYPE_FILESYSTEM, "yes | no", "MOUNTED", boolean_table);
+	    ZFS_TYPE_FILESYSTEM, "yes | no", "MOUNTED", boolean_table, NULL);
 	zprop_register_index(ZFS_PROP_DEFER_DESTROY, "defer_destroy", 0,
 	    PROP_READONLY, ZFS_TYPE_SNAPSHOT, "yes | no", "DEFER_DESTROY",
-	    boolean_table);
+	    boolean_table, NULL);
 
 	/* set once index properties */
 	zprop_register_index(ZFS_PROP_NORMALIZE, "normalization", 0,
 	    PROP_ONETIME, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
 	    "none | formC | formD | formKC | formKD", "NORMALIZATION",
-	    normalize_table);
+	    normalize_table, NULL);
 	zprop_register_index(ZFS_PROP_CASE, "casesensitivity",
 	    ZFS_CASE_SENSITIVE, PROP_ONETIME, ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_SNAPSHOT,
-	    "sensitive | insensitive | mixed", "CASE", case_table);
+	    "sensitive | insensitive | mixed", "CASE", case_table, NULL);
 
 	/* set once index (boolean) properties */
 	zprop_register_index(ZFS_PROP_UTF8ONLY, "utf8only", 0, PROP_ONETIME,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
-	    "on | off", "UTF8ONLY", boolean_table);
+	    "on | off", "UTF8ONLY", boolean_table, NULL);
 
 	/* string properties */
 	zprop_register_string(ZFS_PROP_ORIGIN, "origin", NULL, PROP_READONLY,
-	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<snapshot>", "ORIGIN");
+	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<snapshot>", "ORIGIN", NULL);
 	zprop_register_string(ZFS_PROP_CLONES, "clones", NULL, PROP_READONLY,
-	    ZFS_TYPE_SNAPSHOT, "<dataset>[,...]", "CLONES");
+	    ZFS_TYPE_SNAPSHOT, "<dataset>[,...]", "CLONES", NULL);
 	zprop_register_string(ZFS_PROP_MOUNTPOINT, "mountpoint", "/",
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "<path> | legacy | none",
-	    "MOUNTPOINT");
+	    "MOUNTPOINT", NULL);
 	zprop_register_string(ZFS_PROP_SHARENFS, "sharenfs", "off",
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "on | off | share(1M) options",
-	    "SHARENFS");
+	    "SHARENFS", NULL);
 	zprop_register_string(ZFS_PROP_TYPE, "type", NULL, PROP_READONLY,
 	    ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK,
-	    "filesystem | volume | snapshot | bookmark", "TYPE");
+	    "filesystem | volume | snapshot | bookmark", "TYPE", NULL);
 	zprop_register_string(ZFS_PROP_SHARESMB, "sharesmb", "off",
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
-	    "on | off | sharemgr(1M) options", "SHARESMB");
+	    "on | off | sharemgr(1M) options", "SHARESMB", NULL);
 	zprop_register_string(ZFS_PROP_MLSLABEL, "mlslabel",
 	    ZFS_MLSLABEL_DEFAULT, PROP_INHERIT, ZFS_TYPE_DATASET,
-	    "<sensitivity label>", "MLSLABEL");
+	    "<sensitivity label>", "MLSLABEL", NULL);
 	zprop_register_string(ZFS_PROP_SELINUX_CONTEXT, "context",
 	    "none", PROP_DEFAULT, ZFS_TYPE_DATASET, "<selinux context>",
-	    "CONTEXT");
+	    "CONTEXT", NULL);
 	zprop_register_string(ZFS_PROP_SELINUX_FSCONTEXT, "fscontext",
 	    "none", PROP_DEFAULT, ZFS_TYPE_DATASET, "<selinux fscontext>",
-	    "FSCONTEXT");
+	    "FSCONTEXT", NULL);
 	zprop_register_string(ZFS_PROP_SELINUX_DEFCONTEXT, "defcontext",
 	    "none", PROP_DEFAULT, ZFS_TYPE_DATASET, "<selinux defcontext>",
-	    "DEFCONTEXT");
+	    "DEFCONTEXT", NULL);
 	zprop_register_string(ZFS_PROP_SELINUX_ROOTCONTEXT, "rootcontext",
 	    "none", PROP_DEFAULT, ZFS_TYPE_DATASET, "<selinux rootcontext>",
-	    "ROOTCONTEXT");
+	    "ROOTCONTEXT", NULL);
 
 	/* readonly number properties */
 	zprop_register_number(ZFS_PROP_USED, "used", 0, PROP_READONLY,
-	    ZFS_TYPE_DATASET, "<size>", "USED");
+	    ZFS_TYPE_DATASET, "<size>", "USED", NULL);
 	zprop_register_number(ZFS_PROP_AVAILABLE, "available", 0, PROP_READONLY,
-	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>", "AVAIL");
+	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>", "AVAIL", NULL);
 	zprop_register_number(ZFS_PROP_REFERENCED, "referenced", 0,
-	    PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "REFER");
+	    PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "REFER", NULL);
 	zprop_register_number(ZFS_PROP_COMPRESSRATIO, "compressratio", 0,
 	    PROP_READONLY, ZFS_TYPE_DATASET,
-	    "<1.00x or higher if compressed>", "RATIO");
+	    "<1.00x or higher if compressed>", "RATIO", NULL);
 	zprop_register_number(ZFS_PROP_REFRATIO, "refcompressratio", 0,
 	    PROP_READONLY, ZFS_TYPE_DATASET,
-	    "<1.00x or higher if compressed>", "REFRATIO");
+	    "<1.00x or higher if compressed>", "REFRATIO", NULL);
 	zprop_register_number(ZFS_PROP_VOLBLOCKSIZE, "volblocksize",
 	    ZVOL_DEFAULT_BLOCKSIZE, PROP_ONETIME,
-	    ZFS_TYPE_VOLUME, "512 to 128k, power of 2",	"VOLBLOCK");
+	    ZFS_TYPE_VOLUME, "512 to 128k, power of 2",	"VOLBLOCK", NULL);
 	zprop_register_number(ZFS_PROP_USEDSNAP, "usedbysnapshots", 0,
 	    PROP_READONLY, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>",
-	    "USEDSNAP");
+	    "USEDSNAP", NULL);
 	zprop_register_number(ZFS_PROP_USEDDS, "usedbydataset", 0,
 	    PROP_READONLY, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>",
-	    "USEDDS");
+	    "USEDDS", NULL);
 	zprop_register_number(ZFS_PROP_USEDCHILD, "usedbychildren", 0,
 	    PROP_READONLY, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>",
-	    "USEDCHILD");
+	    "USEDCHILD", NULL);
 	zprop_register_number(ZFS_PROP_USEDREFRESERV, "usedbyrefreservation", 0,
 	    PROP_READONLY,
-	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>", "USEDREFRESERV");
+	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>", "USEDREFRESERV", NULL);
 	zprop_register_number(ZFS_PROP_USERREFS, "userrefs", 0, PROP_READONLY,
-	    ZFS_TYPE_SNAPSHOT, "<count>", "USERREFS");
+	    ZFS_TYPE_SNAPSHOT, "<count>", "USERREFS", NULL);
 	zprop_register_number(ZFS_PROP_WRITTEN, "written", 0, PROP_READONLY,
-	    ZFS_TYPE_DATASET, "<size>", "WRITTEN");
+	    ZFS_TYPE_DATASET, "<size>", "WRITTEN", NULL);
 	zprop_register_number(ZFS_PROP_LOGICALUSED, "logicalused", 0,
-	    PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "LUSED");
+	    PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "LUSED", NULL);
 	zprop_register_number(ZFS_PROP_LOGICALREFERENCED, "logicalreferenced",
-	    0, PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "LREFER");
+	    0, PROP_READONLY, ZFS_TYPE_DATASET, "<size>", "LREFER", NULL);
 
 	/* default number properties */
 	zprop_register_number(ZFS_PROP_QUOTA, "quota", 0, PROP_DEFAULT,
-	    ZFS_TYPE_FILESYSTEM, "<size> | none", "QUOTA");
+	    ZFS_TYPE_FILESYSTEM, "<size> | none", "QUOTA", NULL);
 	zprop_register_number(ZFS_PROP_RESERVATION, "reservation", 0,
 	    PROP_DEFAULT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "<size> | none", "RESERV");
+	    "<size> | none", "RESERV", NULL);
 	zprop_register_number(ZFS_PROP_VOLSIZE, "volsize", 0, PROP_DEFAULT,
-	    ZFS_TYPE_SNAPSHOT | ZFS_TYPE_VOLUME, "<size>", "VOLSIZE");
+	    ZFS_TYPE_SNAPSHOT | ZFS_TYPE_VOLUME, "<size>", "VOLSIZE", NULL);
 	zprop_register_number(ZFS_PROP_REFQUOTA, "refquota", 0, PROP_DEFAULT,
-	    ZFS_TYPE_FILESYSTEM, "<size> | none", "REFQUOTA");
+	    ZFS_TYPE_FILESYSTEM, "<size> | none", "REFQUOTA", NULL);
 	zprop_register_number(ZFS_PROP_REFRESERVATION, "refreservation", 0,
 	    PROP_DEFAULT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "<size> | none", "REFRESERV");
+	    "<size> | none", "REFRESERV", NULL);
 
 	/* inherit number properties */
 	zprop_register_number(ZFS_PROP_RECORDSIZE, "recordsize",
 	    SPA_MAXBLOCKSIZE, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "512 to 128k, power of 2", "RECSIZE");
+	    ZFS_TYPE_FILESYSTEM, "512 to 128k, power of 2", "RECSIZE", NULL);
 
 	/* hidden properties */
 	zprop_register_hidden(ZFS_PROP_CREATETXG, "createtxg", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "CREATETXG");
+	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "CREATETXG", NULL);
 	zprop_register_hidden(ZFS_PROP_NUMCLONES, "numclones", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_SNAPSHOT, "NUMCLONES");
+	    PROP_READONLY, ZFS_TYPE_SNAPSHOT, "NUMCLONES", NULL);
 	zprop_register_hidden(ZFS_PROP_NAME, "name", PROP_TYPE_STRING,
-	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "NAME");
+	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "NAME", NULL);
 	zprop_register_hidden(ZFS_PROP_ISCSIOPTIONS, "iscsioptions",
-	    PROP_TYPE_STRING, PROP_INHERIT, ZFS_TYPE_VOLUME, "ISCSIOPTIONS");
+	    PROP_TYPE_STRING, PROP_INHERIT, ZFS_TYPE_VOLUME, "ISCSIOPTIONS", NULL);
 	zprop_register_hidden(ZFS_PROP_STMF_SHAREINFO, "stmf_sbd_lu",
 	    PROP_TYPE_STRING, PROP_INHERIT, ZFS_TYPE_VOLUME,
-	    "STMF_SBD_LU");
+	    "STMF_SBD_LU", NULL);
 	zprop_register_hidden(ZFS_PROP_GUID, "guid", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "GUID");
+	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "GUID", NULL);
 	zprop_register_hidden(ZFS_PROP_USERACCOUNTING, "useraccounting",
 	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_DATASET,
-	    "USERACCOUNTING");
+	    "USERACCOUNTING", NULL);
 	zprop_register_hidden(ZFS_PROP_UNIQUE, "unique", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET, "UNIQUE");
+	    PROP_READONLY, ZFS_TYPE_DATASET, "UNIQUE", NULL);
 	zprop_register_hidden(ZFS_PROP_OBJSETID, "objsetid", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET, "OBJSETID");
+	    PROP_READONLY, ZFS_TYPE_DATASET, "OBJSETID", NULL);
 	zprop_register_hidden(ZFS_PROP_INCONSISTENT, "inconsistent",
-	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_DATASET, "INCONSISTENT");
+	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_DATASET, "INCONSISTENT", NULL);
 
 	/*
 	 * Property to be removed once libbe is integrated
 	 */
 	zprop_register_hidden(ZFS_PROP_PRIVATE, "priv_prop",
 	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_FILESYSTEM,
-	    "PRIV_PROP");
+	    "PRIV_PROP", NULL);
 
 	/* oddball properties */
 	zprop_register_impl(ZFS_PROP_CREATION, "creation", PROP_TYPE_NUMBER, 0,
 	    NULL, PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK,
-	    "<date>", "CREATION", B_FALSE, B_TRUE, NULL);
+	    "<date>", "CREATION", B_FALSE, B_TRUE, NULL, NULL);
 }
 
 boolean_t
@@ -677,6 +677,23 @@ zfs_prop_align_right(zfs_prop_t prop)
 
 #endif
 
+boolean_t
+zfs_prop_special(zfs_prop_t prop)
+{
+	zprop_desc_t *pd = &zfs_prop_table[prop];
+	return (pd->pd_special != NULL);
+}
+
+int
+zfs_prop_call_special(zfs_prop_t prop, const void *data_in, void **data_out,
+    zprop_special_cb_f **cb)
+{
+	zprop_desc_t *pd = &zfs_prop_table[prop];
+	if (pd->pd_special == NULL)
+		return (ENOENT);
+	return ((*pd->pd_special)(prop, data_in, data_out, cb));
+}
+
 #if defined(_KERNEL) && defined(HAVE_SPL)
 static int __init
 zcommon_init(void)
@@ -717,5 +734,7 @@ EXPORT_SYMBOL(zfs_prop_userquota);
 EXPORT_SYMBOL(zfs_prop_index_to_string);
 EXPORT_SYMBOL(zfs_prop_string_to_index);
 EXPORT_SYMBOL(zfs_prop_valid_for_type);
+EXPORT_SYMBOL(zfs_prop_special);
+EXPORT_SYMBOL(zfs_prop_call_special);
 
 #endif

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -66,73 +66,73 @@ zpool_prop_init(void)
 
 	/* string properties */
 	zprop_register_string(ZPOOL_PROP_ALTROOT, "altroot", NULL, PROP_DEFAULT,
-	    ZFS_TYPE_POOL, "<path>", "ALTROOT");
+	    ZFS_TYPE_POOL, "<path>", "ALTROOT", NULL);
 	zprop_register_string(ZPOOL_PROP_BOOTFS, "bootfs", NULL, PROP_DEFAULT,
-	    ZFS_TYPE_POOL, "<filesystem>", "BOOTFS");
+	    ZFS_TYPE_POOL, "<filesystem>", "BOOTFS", NULL);
 	zprop_register_string(ZPOOL_PROP_CACHEFILE, "cachefile", NULL,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "<file> | none", "CACHEFILE");
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<file> | none", "CACHEFILE", NULL);
 	zprop_register_string(ZPOOL_PROP_COMMENT, "comment", NULL,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "<comment-string>", "COMMENT");
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<comment-string>", "COMMENT", NULL);
 
 	/* readonly number properties */
 	zprop_register_number(ZPOOL_PROP_SIZE, "size", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<size>", "SIZE");
+	    ZFS_TYPE_POOL, "<size>", "SIZE", NULL);
 	zprop_register_number(ZPOOL_PROP_FREE, "free", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<size>", "FREE");
+	    ZFS_TYPE_POOL, "<size>", "FREE", NULL);
 	zprop_register_number(ZPOOL_PROP_FREEING, "freeing", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<size>", "FREEING");
+	    ZFS_TYPE_POOL, "<size>", "FREEING", NULL);
 	zprop_register_number(ZPOOL_PROP_LEAKED, "leaked", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<size>", "LEAKED");
+	    ZFS_TYPE_POOL, "<size>", "LEAKED", NULL);
 	zprop_register_number(ZPOOL_PROP_ALLOCATED, "allocated", 0,
-	    PROP_READONLY, ZFS_TYPE_POOL, "<size>", "ALLOC");
+	    PROP_READONLY, ZFS_TYPE_POOL, "<size>", "ALLOC", NULL);
 	zprop_register_number(ZPOOL_PROP_EXPANDSZ, "expandsize", 0,
-	    PROP_READONLY, ZFS_TYPE_POOL, "<size>", "EXPANDSZ");
+	    PROP_READONLY, ZFS_TYPE_POOL, "<size>", "EXPANDSZ", NULL);
 	zprop_register_number(ZPOOL_PROP_FRAGMENTATION, "fragmentation", 0,
-	    PROP_READONLY, ZFS_TYPE_POOL, "<percent>", "FRAG");
+	    PROP_READONLY, ZFS_TYPE_POOL, "<percent>", "FRAG", NULL);
 	zprop_register_number(ZPOOL_PROP_CAPACITY, "capacity", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<size>", "CAP");
+	    ZFS_TYPE_POOL, "<size>", "CAP", NULL);
 	zprop_register_number(ZPOOL_PROP_GUID, "guid", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<guid>", "GUID");
+	    ZFS_TYPE_POOL, "<guid>", "GUID", NULL);
 	zprop_register_number(ZPOOL_PROP_HEALTH, "health", 0, PROP_READONLY,
-	    ZFS_TYPE_POOL, "<state>", "HEALTH");
+	    ZFS_TYPE_POOL, "<state>", "HEALTH", NULL);
 	zprop_register_number(ZPOOL_PROP_DEDUPRATIO, "dedupratio", 0,
 	    PROP_READONLY, ZFS_TYPE_POOL, "<1.00x or higher if deduped>",
-	    "DEDUP");
+	    "DEDUP", NULL);
 
 	/* readonly onetime number properties */
 	zprop_register_number(ZPOOL_PROP_ASHIFT, "ashift", 0, PROP_ONETIME,
-	    ZFS_TYPE_POOL, "<ashift, 9-13, or 0=default>", "ASHIFT");
+	    ZFS_TYPE_POOL, "<ashift, 9-13, or 0=default>", "ASHIFT", NULL);
 
 	/* default number properties */
 	zprop_register_number(ZPOOL_PROP_VERSION, "version", SPA_VERSION,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "<version>", "VERSION");
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<version>", "VERSION", NULL);
 	zprop_register_number(ZPOOL_PROP_DEDUPDITTO, "dedupditto", 0,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "<threshold (min 100)>", "DEDUPDITTO");
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<threshold (min 100)>", "DEDUPDITTO", NULL);
 
 	/* default index (boolean) properties */
 	zprop_register_index(ZPOOL_PROP_DELEGATION, "delegation", 1,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "DELEGATION",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZPOOL_PROP_AUTOREPLACE, "autoreplace", 0,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "REPLACE", boolean_table);
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "REPLACE", boolean_table, NULL);
 	zprop_register_index(ZPOOL_PROP_LISTSNAPS, "listsnapshots", 0,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "LISTSNAPS",
-	    boolean_table);
+	    boolean_table, NULL);
 	zprop_register_index(ZPOOL_PROP_AUTOEXPAND, "autoexpand", 0,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "EXPAND", boolean_table);
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "EXPAND", boolean_table, NULL);
 	zprop_register_index(ZPOOL_PROP_READONLY, "readonly", 0,
-	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "RDONLY", boolean_table);
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "RDONLY", boolean_table, NULL);
 
 	/* default index properties */
 	zprop_register_index(ZPOOL_PROP_FAILUREMODE, "failmode",
 	    ZIO_FAILURE_MODE_WAIT, PROP_DEFAULT, ZFS_TYPE_POOL,
-	    "wait | continue | panic", "FAILMODE", failuremode_table);
+	    "wait | continue | panic", "FAILMODE", failuremode_table, NULL);
 
 	/* hidden properties */
 	zprop_register_hidden(ZPOOL_PROP_NAME, "name", PROP_TYPE_STRING,
-	    PROP_READONLY, ZFS_TYPE_POOL, "NAME");
+	    PROP_READONLY, ZFS_TYPE_POOL, "NAME", NULL);
 	zprop_register_hidden(ZPOOL_PROP_TNAME, "tname", PROP_TYPE_STRING,
-	    PROP_ONETIME, ZFS_TYPE_POOL, "TNAME");
+	    PROP_ONETIME, ZFS_TYPE_POOL, "TNAME", NULL);
 }
 
 /*

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -71,7 +71,8 @@ void
 zprop_register_impl(int prop, const char *name, zprop_type_t type,
     uint64_t numdefault, const char *strdefault, zprop_attr_t attr,
     int objset_types, const char *values, const char *colname,
-    boolean_t rightalign, boolean_t visible, const zprop_index_t *idx_tbl)
+    boolean_t rightalign, boolean_t visible, const zprop_index_t *idx_tbl,
+    zprop_special_f *special_cb)
 {
 	zprop_desc_t *prop_tbl = zprop_get_proptable(objset_types);
 	zprop_desc_t *pd;
@@ -95,6 +96,7 @@ zprop_register_impl(int prop, const char *name, zprop_type_t type,
 	pd->pd_visible = visible;
 	pd->pd_table = idx_tbl;
 	pd->pd_table_size = 0;
+	pd->pd_special = 0;
 	while (idx_tbl && (idx_tbl++)->pi_name != NULL)
 		pd->pd_table_size++;
 }
@@ -102,38 +104,42 @@ zprop_register_impl(int prop, const char *name, zprop_type_t type,
 void
 zprop_register_string(int prop, const char *name, const char *def,
     zprop_attr_t attr, int objset_types, const char *values,
-    const char *colname)
+    const char *colname, zprop_special_f *special_cb)
 {
 	zprop_register_impl(prop, name, PROP_TYPE_STRING, 0, def, attr,
-	    objset_types, values, colname, B_FALSE, B_TRUE, NULL);
+	    objset_types, values, colname, B_FALSE, B_TRUE, NULL, special_cb);
 
 }
 
 void
 zprop_register_number(int prop, const char *name, uint64_t def,
     zprop_attr_t attr, int objset_types, const char *values,
-    const char *colname)
+    const char *colname, zprop_special_f *special_cb)
 {
 	zprop_register_impl(prop, name, PROP_TYPE_NUMBER, def, NULL, attr,
-	    objset_types, values, colname, B_TRUE, B_TRUE, NULL);
+	    objset_types, values, colname, B_TRUE, B_TRUE, NULL,
+	    special_cb);
 }
 
 void
 zprop_register_index(int prop, const char *name, uint64_t def,
     zprop_attr_t attr, int objset_types, const char *values,
-    const char *colname, const zprop_index_t *idx_tbl)
+    const char *colname, const zprop_index_t *idx_tbl,
+    zprop_special_f *special_cb)
 {
 	zprop_register_impl(prop, name, PROP_TYPE_INDEX, def, NULL, attr,
-	    objset_types, values, colname, B_TRUE, B_TRUE, idx_tbl);
+	    objset_types, values, colname, B_TRUE, B_TRUE, idx_tbl,
+	    special_cb);
 }
 
 void
 zprop_register_hidden(int prop, const char *name, zprop_type_t type,
-    zprop_attr_t attr, int objset_types, const char *colname)
+    zprop_attr_t attr, int objset_types, const char *colname,
+    zprop_special_f *special_cb)
 {
 	zprop_register_impl(prop, name, type, 0, NULL, attr,
 	    objset_types, NULL, colname,
-	    type == PROP_TYPE_NUMBER, B_FALSE, NULL);
+	    type == PROP_TYPE_NUMBER, B_FALSE, NULL, special_cb);
 }
 
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1917,7 +1917,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
  * See comment above dmu_objset_find_impl().
  */
 int
-dmu_objset_find(char *name, int func(const char *, void *), void *arg,
+dmu_objset_find(const char *name, int func(const char *, void *), void *arg,
     int flags)
 {
 	spa_t *spa;

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1644,7 +1644,7 @@ dmu_objset_getlist(dsl_pool_t *dp, uint64_t ddobj, int flags,
 	/*
 	 * Iterate over all snapshots.
 	 */
-	if (depth > 1 && (flags & DS_FIND_SNAPSHOTS)) {
+	if (depth >= 1 && (flags & DS_FIND_SNAPSHOTS)) {
 		dsl_dataset_t *ds = parent->dol_ds;
 
 		if (err == 0) {

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2015 by ClusterHQ, Inc. All rights reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -1551,7 +1552,7 @@ dmu_oslnode_alloc(dmu_oslnode_t *parent, dsl_dataset_t *ds)
 {
 	dmu_oslnode_t *child = kmem_zalloc(sizeof (dmu_oslnode_t), KM_SLEEP);
 
-	list_create(&parent->dol_child, sizeof (dmu_oslnode_t),
+	list_create(&child->dol_child, sizeof (dmu_oslnode_t),
 		    offsetof(dmu_oslnode_t, dol_sibling));
 
 	if (parent != NULL)
@@ -1959,6 +1960,72 @@ dmu_fsname(const char *snapname, char *buf)
 	(void) strlcpy(buf, snapname, atp - snapname + 1);
 	return (0);
 }
+
+/* Code for handling userspace interface */
+const char *dmu_objset_types[DMU_OST_NUMTYPES] = {
+	"NONE", "META", "ZPL", "ZVOL", "OTHER", "ANY" };
+
+#define	DMU_OT_COUNT	(sizeof (dmu_objset_types) /\
+	sizeof (&dmu_objset_types[0]))
+
+const char *
+dmu_objset_type_name(dmu_objset_type_t type)
+{
+	return ((type < DMU_OST_NUMTYPES) ? dmu_objset_types[type] : NULL);
+}
+
+nvlist_t *
+dmu_objset_stats_nvlist(dmu_objset_stats_t *stat)
+{
+	nvlist_t *nvl = fnvlist_alloc();
+
+	nvlist_add_uint64(nvl, "dds_num_clones", stat->dds_num_clones);
+	nvlist_add_uint64(nvl, "dds_creation_txg", stat->dds_creation_txg);
+	nvlist_add_uint64(nvl, "dds_guid", stat->dds_guid);
+
+	fnvlist_add_string(nvl, "dds_type",
+	    dmu_objset_type_name(stat->dds_type));
+
+	fnvlist_add_boolean_value(nvl, "dds_is_snapshot",
+	    stat->dds_is_snapshot);
+	fnvlist_add_boolean_value(nvl, "dds_inconsistent",
+	    stat->dds_inconsistent);
+
+	fnvlist_add_string(nvl, "dds_origin", stat->dds_origin);
+
+	return (nvl);
+}
+
+int
+dmu_objset_stat_nvlts(nvlist_t *nvl, dmu_objset_stats_t *stat)
+{
+	char *type;
+	boolean_t issnap, inconsist;
+	int i;
+
+	if (nvlist_lookup_uint64(nvl, "dds_num_clones",
+	    &stat->dds_num_clones) ||
+	    nvlist_lookup_uint64(nvl, "dds_creation_txg",
+	    &stat->dds_creation_txg) ||
+	    nvlist_lookup_uint64(nvl, "dds_guid", &stat->dds_guid) ||
+	    nvlist_lookup_string(nvl, "dds_type", &type) ||
+	    nvlist_lookup_boolean_value(nvl, "dds_is_snapshot", &issnap) ||
+	    nvlist_lookup_boolean_value(nvl, "dds_inconsistent", &inconsist))
+		return (EINVAL);
+
+	stat->dds_inconsistent = inconsist;
+	stat->dds_is_snapshot = issnap;
+
+	for (i = 0; i < DMU_OT_COUNT; i++) {
+		if (strcmp(dmu_objset_types[i], type) == 0) {
+			stat->dds_type = i;
+			return (0);
+		}
+	}
+
+	return (EINVAL);
+}
+
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
 EXPORT_SYMBOL(dmu_objset_zil);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -730,14 +730,14 @@ dmu_send_obj(const char *pool, uint64_t tosnap, uint64_t fromsnap,
 
 int
 dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
-    int outfd, vnode_t *vp, offset_t *off)
+    boolean_t fromorigin, int outfd, vnode_t *vp, offset_t *off)
 {
 	dsl_pool_t *dp;
 	dsl_dataset_t *ds;
 	int err;
 	boolean_t owned = B_FALSE;
 
-	if (fromsnap != NULL && strpbrk(fromsnap, "@#") == NULL)
+	if ((fromsnap != NULL || fromorigin) && strpbrk(fromsnap, "@#") == NULL)
 		return (SET_ERROR(EINVAL));
 
 	err = dsl_pool_hold(tosnap, FTAG, &dp);
@@ -759,7 +759,32 @@ dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
 		return (err);
 	}
 
-	if (fromsnap != NULL) {
+	if (fromorigin) {
+		zfs_bookmark_phys_t zb;
+		dsl_dataset_t *fromds;
+		uint64_t fromobj;
+
+		if (!dsl_dir_is_clone(tosnap->ds_dir)) {
+			dsl_dataset_rele(ds, FTAG);
+			dsl_pool_rele(dp, FTAG);
+			return (SET_ERROR(EINVAL));
+		}
+		fromobj = ds->ds_dir->dd_phys->dd_origin_obj;
+		err = dsl_dataset_hold_obj(dp, fromobj, FTAG, &fromds);
+		if (err =! 0) {
+			dsl_dataset_rele(ds, FTAG);
+			dsl_pool_rele(dp, FTAG);
+			return (err);
+		}
+		zb.zbm_creation_time =
+		    fromds->ds_phys->ds_creation_time;
+		zb.zbm_creation_txg =
+		    fromds->ds_phys->ds_creation_txg;
+		zb.zbm_guid = fromds->ds_phys->ds_guid;
+		dsl_dataset_rele(fromds, FTAG);
+		err = dmu_send_impl(FTAG, dp, ds, &zb, B_TRUE, embedok,
+		    outfd, vp, off);
+	} else if (fromsnap != NULL) {
 		zfs_bookmark_phys_t zb;
 		boolean_t is_clone = B_FALSE;
 		int fsnamelen = strchr(tosnap, '@') - tosnap;

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -764,14 +764,14 @@ dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
 		dsl_dataset_t *fromds;
 		uint64_t fromobj;
 
-		if (!dsl_dir_is_clone(tosnap->ds_dir)) {
+		if (!dsl_dir_is_clone(ds->ds_dir)) {
 			dsl_dataset_rele(ds, FTAG);
 			dsl_pool_rele(dp, FTAG);
 			return (SET_ERROR(EINVAL));
 		}
 		fromobj = ds->ds_dir->dd_phys->dd_origin_obj;
 		err = dsl_dataset_hold_obj(dp, fromobj, FTAG, &fromds);
-		if (err =! 0) {
+		if (err != 0) {
 			dsl_dataset_rele(ds, FTAG);
 			dsl_pool_rele(dp, FTAG);
 			return (err);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -842,7 +842,8 @@ typedef enum dsl_prop_getflags {
 	DSL_PROP_GET_INHERITING = 0x1,	/* searching parent of target ds */
 	DSL_PROP_GET_SNAPSHOT = 0x2,	/* snapshot dataset */
 	DSL_PROP_GET_LOCAL = 0x4,	/* local properties */
-	DSL_PROP_GET_RECEIVED = 0x8	/* received properties */
+	DSL_PROP_GET_RECEIVED = 0x8,	/* received properties */
+	DSL_PROP_GET_INDEX_STR = 0x10	/* index properties as strings */
 } dsl_prop_getflags_t;
 
 static int
@@ -948,6 +949,16 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 			VERIFY(nvlist_add_string(propval, ZPROP_VALUE,
 			    tmp) == 0);
 			kmem_free(tmp, za.za_num_integers);
+		} else if ((flags & DSL_PROP_GET_INDEX_STR) &&
+		    zfs_prop_get_type(prop) == PROP_TYPE_INDEX) {
+			/*
+			 * Index property (returned as string)
+			 */
+			const char *strval;
+			VERIFY0(zfs_prop_index_to_string(prop,
+			    za.za_first_integer, &strval));
+			VERIFY0(nvlist_add_string(propval, ZPROP_VALUE,
+			    strval));
 		} else {
 			/*
 			 * Integer property
@@ -1061,6 +1072,13 @@ int
 dsl_prop_get_all(objset_t *os, nvlist_t **nvp)
 {
 	return (dsl_prop_get_all_ds(os->os_dsl_dataset, nvp, 0));
+}
+
+int
+dsl_prop_get_all_new(objset_t *os, nvlist_t **nvp)
+{
+	return (dsl_prop_get_all_ds(os->os_dsl_dataset, nvp,
+	    DSL_PROP_GET_INDEX_STR));
 }
 
 int

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2511,7 +2511,15 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 	if (zfs_prop_get_type(prop) == PROP_TYPE_STRING)
 		return (-1);
 
-	VERIFY(0 == nvpair_value_uint64(pair, &intval));
+	if (((nvpair_type(pair) == DATA_TYPE_STRING) &&
+	    (zfs_prop_get_type(prop) == PROP_TYPE_INDEX))) {
+		char *strval;
+		if (nvpair_value_string(pair, &strval) != 0)
+			return (-1);
+		if (zfs_prop_string_to_index(prop, strval, &intval) != 0)
+			return (-1);
+	} else
+		VERIFY(0 == nvpair_value_uint64(pair, &intval));
 
 	switch (prop) {
 	case ZFS_PROP_QUOTA:
@@ -2655,20 +2663,29 @@ retry:
 			err = zfs_check_settable(dsname, pair, CRED());
 
 		if (err == 0) {
+			nvlist_t *tnvl = NULL;
 			err = zfs_prop_set_special(dsname, source, pair);
 			if (err == -1) {
 				/*
 				 * For better performance we build up a list of
 				 * properties to set in a single transaction.
 				 */
-				err = nvlist_add_nvpair(genericnvl, pair);
+				tnvl = genericnvl;
 			} else if (err != 0 && nvl != retrynvl) {
 				/*
 				 * This may be a spurious error caused by
 				 * receiving quota and reservation out of order.
 				 * Try again in a second pass.
 				 */
-				err = nvlist_add_nvpair(retrynvl, pair);
+				tnvl = retrynvl;
+			}
+			if (tnvl) {
+				if (nvpair_type(propval) == DATA_TYPE_STRING &&
+				    zfs_prop_get_type(prop) == PROP_TYPE_INDEX)
+					err = nvlist_add_uint64(tnvl, propname,
+					    intval);
+				else
+					err = nvlist_add_nvpair(tnvl, pair);
 			}
 		}
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2612,8 +2612,19 @@ retry:
 			}
 		} else if (err == 0) {
 			if (nvpair_type(propval) == DATA_TYPE_STRING) {
-				if (zfs_prop_get_type(prop) != PROP_TYPE_STRING)
+				switch (zfs_prop_get_type(prop)) {
+				case PROP_TYPE_INDEX:
+					strval = fnvpair_value_string(propval);
+					if (zfs_prop_string_to_index(prop,
+					    strval, &intval) != 0)
+						err = SET_ERROR(EINVAL);
+					break;
+				case PROP_TYPE_STRING:
+					break;
+				default:
 					err = SET_ERROR(EINVAL);
+					break;
+				}
 			} else if (nvpair_type(propval) == DATA_TYPE_UINT64) {
 				const char *unused;
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5420,6 +5420,54 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	return (error);
 }
 
+static int
+zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
+    nvlist_t *opts, uint64_t version)
+{
+	char parentname[MAXNAMELEN];
+	char conflsnap[MAXNAMELEN];
+	dsl_pool_t *dp;
+	dsl_dataset_t *clone;
+	dsl_dataset_t *origin = NULL;
+	dsl_dir_t *dd;
+	char *cp;
+	int error;
+
+	error = dsl_pool_hold(fsname, FTAG, &dp);
+	if (error != 0)
+		return (error);
+
+	error = dsl_dataset_hold(dp, fsname, FTAG, &clone);
+	if (error == 0) {
+		dd = clone->ds_dir;
+		error = dsl_dataset_hold_obj(dd->dd_pool,
+		    dd->dd_phys->dd_origin_obj, FTAG, &origin);
+		if (error != 0) {
+			dsl_dataset_rele(clone, FTAG);
+			dsl_pool_rele(dp, FTAG);
+			return (error);
+		}
+
+		dsl_dataset_name(origin, parentname);
+		dsl_dataset_rele(origin, FTAG);
+		dsl_dataset_rele(clone, FTAG);
+	}
+	dsl_pool_rele(dp, FTAG);
+
+	/*
+	 * We don't need to unmount *all* the origin fs's snapshots, but
+	 * it's easier.
+	 */
+	(void) dmu_objset_find(parentname,
+	    zfs_unmount_snap_cb, NULL, DS_FIND_SNAPSHOTS);
+
+	error = dsl_dataset_promote(fsname, conflsnap);
+	if (error != 0)
+		fnvlist_add_string(outnvl, "conflsnap", conflsnap);
+
+	return (error);
+}
+
 int
 pool_status_check(const char *name, zfs_ioc_namecheck_t type,
     zfs_ioc_poolcheck_t check);
@@ -5509,6 +5557,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_namecheck		= DATASET_NAME,
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_promote",
+	.zvec_func		= zfs_stable_ioc_promote,
+	.zvec_secpolicy		= zfs_secpolicy_promote,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_FALSE,
 	.zvec_allow_log		= B_TRUE,
 },
 {	.zvec_name		= "zfs_destroy_snaps",

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6109,6 +6109,20 @@ zfs_stable_ioc_zfs_destroy(const char *fsname, nvlist_t *innvl,
 	    nvlist_exists(opts, "defer")));
 }
 
+static int
+zfs_stable_ioc_zfs_exists(const char *fsname, nvlist_t *innvl,
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	objset_t *os;
+	int error;
+
+	error = dmu_objset_hold(fsname, FTAG, &os);
+	if (error == 0)
+		dmu_objset_rele(os, FTAG);
+
+	return (error);
+}
+
 /*
  * ioctl table for stable interface.
  * Functions use zfs_/zpool_ prefixes to distinguish between their uses
@@ -6282,6 +6296,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_FALSE,
 	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_exists",
+	.zvec_func		= zfs_stable_ioc_zfs_exists,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
 },
 };
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2015, ClusterHQ, Inc. All rights reserved.
  */
 
 /*
@@ -204,7 +205,9 @@ static uint_t zfs_allow_log_key;
 
 typedef int zfs_ioc_legacy_func_t(zfs_cmd_t *);
 typedef int zfs_ioc_func_t(const char *, nvlist_t *, nvlist_t *);
-typedef int zfs_secpolicy_func_t(zfs_cmd_t *, nvlist_t *, cred_t *);
+typedef int zfs_ioc_stable_func_t(const char *, nvlist_t *, nvlist_t *,
+	nvlist_t *, uint64_t);
+typedef int zfs_secpolicy_func_t(zfs_cmd_t *, nvlist_t *, nvlist_t *, cred_t *);
 
 typedef enum {
 	NO_NAME,
@@ -228,6 +231,16 @@ typedef struct zfs_ioc_vec {
 	boolean_t		zvec_smush_outnvlist;
 	const char		*zvec_name;
 } zfs_ioc_vec_t;
+
+typedef struct zfs_stable_ioc_vec {
+	zfs_ioc_stable_func_t	*zvec_func;
+	zfs_secpolicy_func_t	*zvec_secpolicy;
+	zfs_ioc_namecheck_t	zvec_namecheck;
+	boolean_t		zvec_allow_log;
+	zfs_ioc_poolcheck_t	zvec_pool_check;
+	boolean_t		zvec_smush_outnvlist;
+	const char *const	zvec_name;
+} zfs_stable_ioc_vec_t;
 
 /* This array is indexed by zfs_userquota_prop_t */
 static const char *userquota_perms[] = {
@@ -404,7 +417,7 @@ zfs_log_history(zfs_cmd_t *zc)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_none(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_none(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	return (0);
 }
@@ -415,7 +428,7 @@ zfs_secpolicy_none(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_read(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_read(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	if (INGLOBALZONE(curproc) ||
 	    zone_dataset_visible(zc->zc_name, NULL))
@@ -676,7 +689,8 @@ zfs_secpolicy_setprop(const char *dsname, zfs_prop_t prop, nvpair_t *propval,
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_set_fsacl(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_set_fsacl(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	int error;
 
@@ -693,7 +707,8 @@ zfs_secpolicy_set_fsacl(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_rollback(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_rollback(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	return (zfs_secpolicy_write_perms(zc->zc_name,
 	    ZFS_DELEG_PERM_ROLLBACK, cr));
@@ -701,7 +716,7 @@ zfs_secpolicy_rollback(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_send(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_send(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	dsl_pool_t *dp;
 	dsl_dataset_t *ds;
@@ -737,7 +752,8 @@ zfs_secpolicy_send(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_send_new(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_send_new(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	return (zfs_secpolicy_write_perms(zc->zc_name,
 	    ZFS_DELEG_PERM_SEND, cr));
@@ -746,7 +762,8 @@ zfs_secpolicy_send_new(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 #ifdef HAVE_SMB_SHARE
 /* ARGSUSED */
 static int
-zfs_secpolicy_deleg_share(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_deleg_share(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	vnode_t *vp;
 	int error;
@@ -771,7 +788,7 @@ zfs_secpolicy_deleg_share(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 #endif /* HAVE_SMB_SHARE */
 
 int
-zfs_secpolicy_share(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_share(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 #ifdef HAVE_SMB_SHARE
 	if (!INGLOBALZONE(curproc))
@@ -788,7 +805,8 @@ zfs_secpolicy_share(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 }
 
 int
-zfs_secpolicy_smb_acl(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_smb_acl(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 #ifdef HAVE_SMB_SHARE
 	if (!INGLOBALZONE(curproc))
@@ -840,7 +858,8 @@ zfs_secpolicy_destroy_perms(const char *name, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_destroy(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_destroy(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	return (zfs_secpolicy_destroy_perms(zc->zc_name, cr));
 }
@@ -851,7 +870,8 @@ zfs_secpolicy_destroy(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_destroy_snaps(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_destroy_snaps(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	nvlist_t *snaps;
 	nvpair_t *pair, *nextpair;
@@ -913,14 +933,15 @@ zfs_secpolicy_rename_perms(const char *from, const char *to, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_rename(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_rename(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	return (zfs_secpolicy_rename_perms(zc->zc_name, zc->zc_value, cr));
 }
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_promote(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_promote(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	dsl_pool_t *dp;
 	dsl_dataset_t *clone;
@@ -968,7 +989,7 @@ zfs_secpolicy_promote(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_recv(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_recv(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	int error;
 
@@ -996,7 +1017,8 @@ zfs_secpolicy_snapshot_perms(const char *name, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	nvlist_t *snaps;
 	int error = 0;
@@ -1027,7 +1049,8 @@ zfs_secpolicy_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_bookmark(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_bookmark(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	int error = 0;
 	nvpair_t *pair;
@@ -1053,7 +1076,8 @@ zfs_secpolicy_bookmark(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_destroy_bookmarks(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_destroy_bookmarks(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	nvpair_t *pair, *nextpair;
 	int error = 0;
@@ -1094,7 +1118,8 @@ zfs_secpolicy_destroy_bookmarks(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_log_history(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_log_history(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	/*
 	 * Even root must have a proper TSD so that we know what pool
@@ -1106,7 +1131,8 @@ zfs_secpolicy_log_history(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 }
 
 static int
-zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	char	parentname[MAXNAMELEN];
 	int	error;
@@ -1135,7 +1161,7 @@ zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_config(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_config(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	if (secpolicy_sys_config(cr, B_FALSE) != 0)
 		return (SET_ERROR(EPERM));
@@ -1148,7 +1174,7 @@ zfs_secpolicy_config(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_diff(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_diff(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	int error;
 
@@ -1164,14 +1190,15 @@ zfs_secpolicy_diff(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  */
 /* ARGSUSED */
 static int
-zfs_secpolicy_inject(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_inject(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	return (secpolicy_zinject(cr));
 }
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_inherit_prop(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_inherit_prop(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	zfs_prop_t prop = zfs_name_to_prop(zc->zc_value);
 
@@ -1187,9 +1214,10 @@ zfs_secpolicy_inherit_prop(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 }
 
 static int
-zfs_secpolicy_userspace_one(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_userspace_one(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
-	int err = zfs_secpolicy_read(zc, innvl, cr);
+	int err = zfs_secpolicy_read(zc, innvl, opts, cr);
 	if (err)
 		return (err);
 
@@ -1216,9 +1244,10 @@ zfs_secpolicy_userspace_one(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 }
 
 static int
-zfs_secpolicy_userspace_many(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_userspace_many(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
-	int err = zfs_secpolicy_read(zc, innvl, cr);
+	int err = zfs_secpolicy_read(zc, innvl, opts, cr);
 	if (err)
 		return (err);
 
@@ -1231,7 +1260,8 @@ zfs_secpolicy_userspace_many(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_userspace_upgrade(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_userspace_upgrade(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	return (zfs_secpolicy_setprop(zc->zc_name, ZFS_PROP_VERSION,
 	    NULL, cr));
@@ -1239,7 +1269,7 @@ zfs_secpolicy_userspace_upgrade(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_hold(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_hold(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 {
 	nvpair_t *pair;
 	nvlist_t *holds;
@@ -1265,7 +1295,8 @@ zfs_secpolicy_hold(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_release(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_release(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	nvpair_t *pair;
 	int error;
@@ -1288,7 +1319,8 @@ zfs_secpolicy_release(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  * Policy for allowing temporary snapshots to be taken or released
  */
 static int
-zfs_secpolicy_tmp_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
+zfs_secpolicy_tmp_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
 {
 	/*
 	 * A temporary snapshot is the same as a snapshot,
@@ -1303,11 +1335,11 @@ zfs_secpolicy_tmp_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 	error = zfs_secpolicy_snapshot_perms(zc->zc_name, cr);
 	if (error == 0)
-		error = zfs_secpolicy_hold(zc, innvl, cr);
+		error = zfs_secpolicy_hold(zc, innvl, NULL, cr);
 	if (error == 0)
-		error = zfs_secpolicy_release(zc, innvl, cr);
+		error = zfs_secpolicy_release(zc, innvl, NULL, cr);
 	if (error == 0)
-		error = zfs_secpolicy_destroy(zc, innvl, cr);
+		error = zfs_secpolicy_destroy(zc, innvl, NULL, cr);
 	return (error);
 }
 
@@ -4012,7 +4044,8 @@ zfs_check_clearable(char *dataset, nvlist_t *props, nvlist_t **errlist)
 
 		(void) strcpy(zc->zc_value, nvpair_name(pair));
 		if ((err = zfs_check_settable(dataset, pair, CRED())) != 0 ||
-		    (err = zfs_secpolicy_inherit_prop(zc, NULL, CRED())) != 0) {
+		    (err = zfs_secpolicy_inherit_prop(zc, NULL, NULL, CRED()))
+		    != 0) {
 			VERIFY(nvlist_remove_nvpair(props, pair) == 0);
 			VERIFY(nvlist_add_int32(errors,
 			    zc->zc_value, err) == 0);
@@ -5381,6 +5414,331 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	return (error);
 }
 
+int
+pool_status_check(const char *name, zfs_ioc_namecheck_t type,
+    zfs_ioc_poolcheck_t check);
+
+#define	LIBZFS_CORE_WRAPPER_FUNC_2NAME(oldname, newname)		\
+static int								\
+zfs_stable_ioc_zfs_##newname(const char *fsname, nvlist_t *innvl,	\
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version) {		\
+	return (zfs_ioc_##oldname(fsname, innvl, outnvl));		\
+}
+
+#define	LIBZFS_CORE_WRAPPER_FUNC(name)					\
+LIBZFS_CORE_WRAPPER_FUNC_2NAME(name, name)
+
+LIBZFS_CORE_WRAPPER_FUNC(snapshot)
+LIBZFS_CORE_WRAPPER_FUNC(log_history)
+LIBZFS_CORE_WRAPPER_FUNC(space_snaps)
+LIBZFS_CORE_WRAPPER_FUNC_2NAME(send_new, send)
+LIBZFS_CORE_WRAPPER_FUNC(send_space)
+LIBZFS_CORE_WRAPPER_FUNC(create)
+LIBZFS_CORE_WRAPPER_FUNC(clone)
+LIBZFS_CORE_WRAPPER_FUNC(destroy_snaps)
+LIBZFS_CORE_WRAPPER_FUNC(hold)
+LIBZFS_CORE_WRAPPER_FUNC(release)
+LIBZFS_CORE_WRAPPER_FUNC(get_holds)
+LIBZFS_CORE_WRAPPER_FUNC(rollback)
+LIBZFS_CORE_WRAPPER_FUNC(bookmark)
+LIBZFS_CORE_WRAPPER_FUNC(get_bookmarks)
+LIBZFS_CORE_WRAPPER_FUNC(destroy_bookmarks)
+
+/*
+ * ioctl table for stable interface.
+ * Functions use zfs_/zpool_ prefixes to distinguish between their uses
+ * XXX: Sort entries and implement binary search.
+ */
+static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
+{	.zvec_name		= "zfs_snapshot",
+	.zvec_func		= zfs_stable_ioc_zfs_snapshot,
+	.zvec_secpolicy		= zfs_secpolicy_snapshot,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_log_history",
+	.zvec_func		= zfs_stable_ioc_zfs_log_history,
+	.zvec_secpolicy		= zfs_secpolicy_log_history,
+	.zvec_namecheck		= NO_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_space_snaps",
+	.zvec_func		= zfs_stable_ioc_zfs_space_snaps,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_send",
+	.zvec_func		= zfs_stable_ioc_zfs_send,
+	.zvec_secpolicy		= zfs_secpolicy_send_new,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_send_space",
+	.zvec_func		= zfs_stable_ioc_zfs_send_space,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_create",
+	.zvec_func		= zfs_stable_ioc_zfs_create,
+	.zvec_secpolicy		= zfs_secpolicy_config,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_clone",
+	.zvec_func		= zfs_stable_ioc_zfs_clone,
+	.zvec_secpolicy		= zfs_secpolicy_create_clone,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_destroy_snaps",
+	.zvec_func		= zfs_stable_ioc_zfs_destroy_snaps,
+	.zvec_secpolicy		= zfs_secpolicy_destroy_snaps,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_hold",
+	.zvec_func		= zfs_stable_ioc_zfs_hold,
+	.zvec_secpolicy		= zfs_secpolicy_hold,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_release",
+	.zvec_func		= zfs_stable_ioc_zfs_release,
+	.zvec_secpolicy		= zfs_secpolicy_release,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_get_holds",
+	.zvec_func		= zfs_stable_ioc_zfs_get_holds,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_rollback",
+	.zvec_func		= zfs_stable_ioc_zfs_rollback,
+	.zvec_secpolicy		= zfs_secpolicy_rollback,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_bookmark",
+	.zvec_func		= zfs_stable_ioc_zfs_bookmark,
+	.zvec_secpolicy		= zfs_secpolicy_bookmark,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_get_bookmarks",
+	.zvec_func		= zfs_stable_ioc_zfs_get_bookmarks,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_destroy_bookmarks",
+	.zvec_func		= zfs_stable_ioc_zfs_destroy_bookmarks,
+	.zvec_secpolicy		= zfs_secpolicy_destroy_bookmarks,
+	.zvec_namecheck		= POOL_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
+};
+
+static const ssize_t zfs_stable_ioc_vec_count =
+    sizeof (zfs_stable_ioc_vec) / sizeof (zfs_stable_ioc_vec_t);
+
+/* Helper function to validate names */
+static inline int
+zfs_namecheck(const char *name, zfs_ioc_namecheck_t namecheck,
+    zfs_ioc_poolcheck_t pool_check) {
+	int error = 0;
+
+	switch (namecheck) {
+	case POOL_NAME:
+		if (pool_namecheck(name, NULL, NULL) != 0)
+			error = SET_ERROR(EINVAL);
+		else
+			error = pool_status_check(name,
+			    namecheck, pool_check);
+		break;
+
+	case DATASET_NAME:
+		if (dataset_namecheck(name, NULL, NULL) != 0)
+			error = SET_ERROR(EINVAL);
+		else
+			error = pool_status_check(name,
+			    namecheck, pool_check);
+		break;
+
+	case NO_NAME:
+		break;
+	}
+
+	return (error);
+}
+
+/*
+ * Stable API
+ * We use an XDR-encoded nvlist for input, which is encapsulated inside the
+ * legacy zfs_cmd_t.
+ *
+ * The format is:
+ *
+ * zc->zc_name -> dataset/pool name
+ * zc->zc_nvlist_src: {
+ *     "cmd" -> command name (string)
+ *     "version" -> command version (uint64)
+ *     "opts" -> command specific options (nvlist)
+ *     "innvl" -> command specific input data
+ * }
+ *
+ * Malformed XDR-encoded nvlists will result in get_nvlist() returning an error
+ * from nvlist_unpack(), which fails early. Consequently, all strings can be
+ * safely assumed to be NULL terminated.
+ *
+ * Names of commands focused on the DSL are prefixed with "zfs_" while names of
+ * commands focused on the SPA are prefixed with "zpool_".
+ *
+ * XXX: Unit tests are necessary, especially for malformed XDR-encoded nvlist
+ * inputs.
+ */
+static int
+zfs_ioc_stable(zfs_cmd_t *zc)
+{
+	const char *name = zc->zc_name;
+	char *cmd;
+	nvlist_t *mnvl, *innvl, *outnvl, *opts;
+	uint64_t version;
+	int error = 0;
+	ssize_t i;
+
+	zc->zc_name[sizeof (zc->zc_name) - 1] = '\0';
+
+	if (zc->zc_nvlist_src_size != 0) {
+		error = get_nvlist(zc->zc_nvlist_src, zc->zc_nvlist_src_size,
+		    zc->zc_iflags, &mnvl);
+		if (error != 0)
+			goto out;
+	}
+
+	if ((error = nvlist_lookup_string(mnvl, "cmd", &cmd)))
+		return (error);
+
+	if ((error = nvlist_lookup_nvlist(mnvl, "innvl", &innvl)))
+		return (error);
+
+	if (nvlist_lookup_nvlist(mnvl, "opts", &opts))
+		opts = NULL;
+
+	if ((error = nvlist_lookup_uint64(mnvl, "version", &version)))
+		return (error);
+
+	/* We do not support sequence numbers above 0 right now */
+	if (version != 0)
+		return (EINVAL);
+	/*
+	 * Ensure that all pool/dataset names are valid before we pass down to
+	 * the lower layers.
+	 */
+	zc->zc_name[sizeof (zc->zc_name) - 1] = '\0';
+
+	for (i = 0; i < zfs_stable_ioc_vec_count; i++) {
+		if (strcmp(zfs_stable_ioc_vec[i].zvec_name, cmd) == 0) {
+			nvlist_t *lognv = NULL;
+			const zfs_stable_ioc_vec_t *vec =
+			    &zfs_stable_ioc_vec[i];
+			nvlist_t *lognv = NULL;
+			spa_t *spa;
+			int puterror = 0;
+
+			error = zfs_namecheck(name, vec->zvec_namecheck,
+			    vec->zvec_pool_check);
+
+			if (error == 0 && (zc->zc_iflags & FKIOCTL))
+				error = vec->zvec_secpolicy(zc,
+				    innvl, opts, CRED());
+
+			if (error)
+				return (error);
+
+			ASSERT(vec->zvec_func);
+			VERIFY0(nvlist_alloc(&outnvl, NV_UNIQUE_NAME,
+			    KM_PUSHPAGE));
+
+			/* XXX: Do we want to log the mnvl as the input nvl? */
+			if (vec->zvec_allow_log) {
+				lognv = fnvlist_alloc();
+				fnvlist_add_string(lognv, ZPOOL_HIST_IOCTL,
+				    "stable");
+				fnvlist_add_nvlist(lognv, ZPOOL_HIST_INPUT_NVL,
+				    mnvl);
+			}
+
+			error = vec->zvec_func(name, innvl, outnvl, opts,
+			    version);
+			if (error == 0 && vec->zvec_allow_log &&
+			    spa_open(zc->zc_name, &spa, FTAG) == 0) {
+				if (!nvlist_empty(outnvl)) {
+					fnvlist_add_nvlist(lognv,
+					    ZPOOL_HIST_OUTPUT_NVL, outnvl);
+				}
+				(void) spa_history_log_nvl(spa, lognv);
+				spa_close(spa, FTAG);
+			}
+			fnvlist_free(lognv);
+
+			if (!nvlist_empty(outnvl) ||
+			    zc->zc_nvlist_dst_size != 0) {
+				int smusherror = 0;
+				if (vec->zvec_smush_outnvlist) {
+					smusherror = nvlist_smush(outnvl,
+					    zc->zc_nvlist_dst_size);
+				}
+				if (smusherror == 0)
+					puterror = put_nvlist(zc, outnvl);
+			}
+
+			if (puterror != 0)
+				error = puterror;
+
+			nvlist_free(outnvl);
+			break;
+
+		}
+	}
+
+out:
+	nvlist_free(mnvl);
+	return (error);
+}
 
 static zfs_ioc_vec_t zfs_ioc_vec[ZFS_IOC_LAST - ZFS_IOC_FIRST];
 
@@ -5551,6 +5909,8 @@ zfs_ioctl_init(void)
 	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_TRUE, B_TRUE);
 
 	/* IOCTLS that use the legacy function signature */
+	zfs_ioctl_register_legacy(ZFS_IOC_LIBZFS_CORE, zfs_ioc_stable,
+	    zfs_secpolicy_none, NO_NAME, B_FALSE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_legacy(ZFS_IOC_POOL_FREEZE, zfs_ioc_pool_freeze,
 	    zfs_secpolicy_config, NO_NAME, B_FALSE, POOL_CHECK_READONLY);
@@ -5917,30 +6277,11 @@ zfsdev_ioctl(struct file *filp, unsigned cmd, unsigned long arg)
 	 * the lower layers.
 	 */
 	zc->zc_name[sizeof (zc->zc_name) - 1] = '\0';
-	switch (vec->zvec_namecheck) {
-	case POOL_NAME:
-		if (pool_namecheck(zc->zc_name, NULL, NULL) != 0)
-			error = SET_ERROR(EINVAL);
-		else
-			error = pool_status_check(zc->zc_name,
-			    vec->zvec_namecheck, vec->zvec_pool_check);
-		break;
-
-	case DATASET_NAME:
-		if (dataset_namecheck(zc->zc_name, NULL, NULL) != 0)
-			error = SET_ERROR(EINVAL);
-		else
-			error = pool_status_check(zc->zc_name,
-			    vec->zvec_namecheck, vec->zvec_pool_check);
-		break;
-
-	case NO_NAME:
-		break;
-	}
-
+	error = zfs_namecheck(zc->zc_name, vec->zvec_namecheck,
+	    vec->zvec_pool_check);
 
 	if (error == 0 && !(flag & FKIOCTL))
-		error = vec->zvec_secpolicy(zc, innvl, CRED());
+		error = vec->zvec_secpolicy(zc, innvl, NULL, CRED());
 
 	if (error != 0)
 		goto out;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -440,6 +440,30 @@ zfs_secpolicy_read(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 	return (SET_ERROR(ENOENT));
 }
 
+/*
+ * Policy for dataset rename operations. Requires rename permission and mount
+ * permission on dataset. Also requires create and mount permission on the new
+ * parent. Must be visible in the local zone.
+ */
+/* ARGSUSED */
+static int
+zfs_secpolicy_rename(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
+{
+	char *newname;
+	int error;
+
+	if (INGLOBALZONE(curproc) ||
+	    zone_dataset_visible(zc->zc_name, NULL))
+		return (0);
+
+	error = nvlist_lookup_string(innvl, "newname", &newname);
+	if (error)
+		return (error);
+
+
+	return (zfs_secpolicy_rename_perms(zc->zc_name, newname, cr));
+}
+
 static int
 zfs_dozonecheck_impl(const char *dataset, uint64_t zoned, cred_t *cr)
 {
@@ -936,7 +960,8 @@ zfs_secpolicy_rename_perms(const char *from, const char *to, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_rename(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
+zfs_secpolicy_rename_legacy(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+	cred_t *cr)
 {
 	return (zfs_secpolicy_rename_perms(zc->zc_name, zc->zc_value, cr));
 }
@@ -2416,6 +2441,7 @@ zfs_ioc_list_next(zfs_cmd_t *zc, boolean_t snapshot)
 	zl.zl_name = zc->zc_name;
 	zl.zl_objset_stats = &zc->zc_objset_stats;
 	zl.zl_cookie = zc->zc_cookie;
+	zl.zl_nvlist = NULL;
 
 	if (snapshot) {
 		zl.zl_obj = zc->zc_obj;
@@ -3835,35 +3861,35 @@ recursive_unmount(const char *fsname, void *arg)
 	return (error);
 }
 
-/*
- * inputs:
- * zc_name	old name of dataset
- * zc_value	new name of dataset
- * zc_cookie	recursive flag (only valid for snapshots)
- *
- * outputs:	none
- */
+/* Note that newname is updated on failure when recursive */
 static int
-zfs_ioc_rename(zfs_cmd_t *zc)
+zfs_rename(const char *oldname, char *newname, boolean_t recursive)
 {
-	boolean_t recursive = zc->zc_cookie & 1;
 	char *at;
 
-	zc->zc_value[sizeof (zc->zc_value) - 1] = '\0';
-	if (dataset_namecheck(zc->zc_value, NULL, NULL) != 0 ||
-	    strchr(zc->zc_value, '%'))
+	/* Caller must NULL terminate newname. */
+	if (dataset_namecheck(newname, NULL, NULL) != 0 ||
+	    strchr(newname, '%'))
 		return (SET_ERROR(EINVAL));
 
-	at = strchr(zc->zc_name, '@');
+	at = strchr(oldname, '@');
 	if (at != NULL) {
 		/* snaps must be in same fs */
 		int error;
+		objset_t *os;
+		dmu_objset_type_t ostype;
 
-		if (strncmp(zc->zc_name, zc->zc_value, at - zc->zc_name + 1))
+		if (strncmp(oldname, newname, at - oldname + 1))
 			return (SET_ERROR(EXDEV));
 		*at = '\0';
-		if (zc->zc_objset_type == DMU_OST_ZFS) {
-			error = dmu_objset_find(zc->zc_name,
+
+		if ((error = dmu_objset_hold(oldname, FTAG, &os)) != 0)
+			return (error);
+		ostype = dmu_objset_type(os);
+		dmu_objset_rele(os, FTAG);
+
+		if (ostype == DMU_OST_ZFS) {
+			error = dmu_objset_find(oldname,
 			    recursive_unmount, at + 1,
 			    recursive ? DS_FIND_CHILDREN : 0);
 			if (error != 0) {
@@ -3871,14 +3897,31 @@ zfs_ioc_rename(zfs_cmd_t *zc)
 				return (error);
 			}
 		}
-		error = dsl_dataset_rename_snapshot(zc->zc_name,
-		    at + 1, strchr(zc->zc_value, '@') + 1, recursive);
+		error = dsl_dataset_rename_snapshot(oldname,
+		    at + 1, strchr(newname, '@') + 1, recursive);
 		*at = '@';
 
 		return (error);
 	} else {
-		return (dsl_dir_rename(zc->zc_name, zc->zc_value));
+		return (dsl_dir_rename(oldname, newname));
 	}
+
+}
+
+/*
+ * inputs:
+ * zc_name	old name of dataset
+ * zc_value	new name of dataset
+ * zc_cookie	recursive flag (only valid for snapshots)
+ *
+ * outputs:
+ * zc_name	name of dataset which failed (only on failure if recursive)
+ */
+static int
+zfs_ioc_rename(zfs_cmd_t *zc)
+{
+	zc->zc_value[sizeof (zc->zc_value) - 1] = '\0';
+	return (zfs_rename(zc->zc_value, zc->zc_name, (zc->zc_cookie & 1)));
 }
 
 static int
@@ -5555,6 +5598,27 @@ zfs_stable_ioc_set_props(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 	return (error);
 }
 
+static int
+zfs_stable_ioc_zfs_rename(const char *oldname, nvlist_t *innvl,
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	char *newname;
+	char buf[ZFS_MAXNAMELEN];
+	int error;
+
+	error = nvlist_lookup_string(innvl, "newname", &newname);
+	if (error)
+		return (error);
+	(void) strlcpy(buf, newname, sizeof (buf));
+
+	error = zfs_rename(oldname, newname,
+	    nvlist_exists(opts, "recursive"));
+	if (error)
+		fnvlist_add_string(outnvl, "name", buf);
+
+	return (error);
+}
+
 int
 pool_status_check(const char *name, zfs_ioc_namecheck_t type,
     zfs_ioc_poolcheck_t check);
@@ -6123,6 +6187,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_smush_outnvlist	= B_FALSE,
 	.zvec_allow_log		= B_TRUE,
 },
+{	.zvec_name		= "zfs_rename",
+	.zvec_func		= zfs_stable_ioc_zfs_rename,
+	.zvec_secpolicy		= zfs_secpolicy_rename,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
+	.zvec_allow_log		= B_TRUE,
+},
 };
 
 static const ssize_t zfs_stable_ioc_vec_count =
@@ -6582,7 +6654,7 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_DESTROY, zfs_ioc_destroy,
 	    zfs_secpolicy_destroy);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_RENAME, zfs_ioc_rename,
-	    zfs_secpolicy_rename);
+	    zfs_secpolicy_rename_legacy);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_RECV, zfs_ioc_recv,
 	    zfs_secpolicy_recv);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_PROMOTE, zfs_ioc_promote,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -212,7 +212,9 @@ typedef int zfs_secpolicy_func_t(zfs_cmd_t *, nvlist_t *, nvlist_t *, cred_t *);
 typedef enum {
 	NO_NAME,
 	POOL_NAME,
-	DATASET_NAME
+	POOL_NAME_OR_EMPTY,
+	DATASET_NAME,
+	DATASET_NAME_OR_EMPTY,
 } zfs_ioc_namecheck_t;
 
 typedef enum {
@@ -2078,6 +2080,8 @@ zfs_ioc_vdev_setfru(zfs_cmd_t *zc)
  * nv				nvlist handle
  * stat				pointer to dmu_objset_stats_t for output
  * os				Objset of filesystem (held by caller)
+ * str_indices			Whether index properties should be translated
+ *				into strings
  *
  * outputs:
  * *nv				property nvlist
@@ -2086,13 +2090,16 @@ zfs_ioc_vdev_setfru(zfs_cmd_t *zc)
  * The caller frees the nvlist on success.
  */
 static int
-zfs_ioc_objset_stats_impl(nvlist_t **nv, dmu_objset_stats_t *stat, objset_t *os)
+zfs_ioc_objset_stats_impl(nvlist_t **nv, dmu_objset_stats_t *stat, objset_t
+	*os, boolean_t str_indices)
 {
 	int error = 0;
+	int (*prop_func)(objset_t *, nvlist_t **) = (str_indices) ?
+	    dsl_prop_get_all_new : dsl_prop_get_all;
 
 	dmu_objset_fast_stat(os, stat);
 
-	if (nv != 0 && (error = dsl_prop_get_all(os, nv)) == 0) {
+	if (nv != 0 && (error = prop_func(os, nv)) == 0) {
 		dmu_objset_stats(os, *nv);
 		/*
 		 * NB: zvol_get_stats() will read the objset contents,
@@ -2134,13 +2141,14 @@ zfs_ioc_objset_stats(zfs_cmd_t *zc)
 
 	error = dmu_objset_hold(zc->zc_name, FTAG, &os);
 	if (error == 0) {
-		error = zfs_ioc_objset_stats_impl(&nv, &zc->zc_objset_stats,
-		    os);
+		nvlist_t **outnvl = (zc->zc_nvlist_dst) ? &nv : NULL;
+		error = zfs_ioc_objset_stats_impl(outnvl, &zc->zc_objset_stats,
+		    os, B_FALSE);
 
 		dmu_objset_rele(os, FTAG);
 	}
 
-	if (error == 0) {
+	if (zc->zc_nvlist_dst && error == 0) {
 		error = put_nvlist(zc, nv);
 		nvlist_free(nv);
 	}
@@ -2300,12 +2308,12 @@ top:
 
 	p = strrchr(zl->zl_name, '/');
 	if (p == NULL || p[1] != '\0')
-		(void) strlcat(zl->zl_name, "/", sizeof (zl->zl_name));
+		(void) strlcat(zl->zl_name, "/", MAXPATHLEN);
 	p = zl->zl_name + strlen(zl->zl_name);
 
 	do {
 		error = dmu_dir_list_next(os,
-		    sizeof (zl->zl_name) - (p - zl->zl_name), p,
+		    MAXPATHLEN - (p - zl->zl_name), p,
 		    NULL, &zl->zl_cookie);
 		if (error == ENOENT)
 			error = SET_ERROR(ESRCH);
@@ -2318,7 +2326,7 @@ top:
 	if (error == 0 && strchr(zl->zl_name, '$') == NULL) {
 		/* fill in the stats */
 		error = zfs_ioc_objset_stats_impl(&zl->zl_nvlist,
-		    zl->zl_objset_stats, os);
+		    zl->zl_objset_stats, os, B_FALSE);
 		if (error == ENOENT) {
 			dmu_objset_rele(os, FTAG);
 			/* we lost a race with destroy, get the next one. */
@@ -2357,13 +2365,13 @@ zfs_ioc_snapshot_list_next_impl(zfs_list_t *zl, boolean_t simple)
 	 * A dataset name of maximum length cannot have any snapshots,
 	 * so exit immediately.
 	 */
-	if (strlcat(zl->zl_name, "@", sizeof (zl->zl_name)) >= MAXNAMELEN) {
+	if (strlcat(zl->zl_name, "@", MAXPATHLEN) >= MAXNAMELEN) {
 		dmu_objset_rele(os, FTAG);
 		return (SET_ERROR(ESRCH));
 	}
 
 	error = dmu_snapshot_list_next(os,
-	    sizeof (zl->zl_name) - strlen(zl->zl_name),
+	    MAXPATHLEN - strlen(zl->zl_name),
 	    zl->zl_name + strlen(zl->zl_name), &zl->zl_obj, &zl->zl_cookie,
 	    NULL);
 
@@ -2379,7 +2387,7 @@ zfs_ioc_snapshot_list_next_impl(zfs_list_t *zl, boolean_t simple)
 			error = dmu_objset_from_ds(ds, &ossnap);
 			if (error == 0) {
 				error = zfs_ioc_objset_stats_impl(&nv,
-				    zl->zl_objset_stats, ossnap);
+				    zl->zl_objset_stats, ossnap, B_FALSE);
 			}
 			dsl_dataset_rele(ds, FTAG);
 			if (error)
@@ -5426,7 +5434,7 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 
 static int
 zfs_stable_ioc_send_progress(const char *snapname, nvlist_t *innvl,
-     nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
 {
 	dsl_pool_t *dp;
 	dsl_dataset_t *ds;
@@ -5484,7 +5492,6 @@ zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 	dsl_dataset_t *clone;
 	dsl_dataset_t *origin = NULL;
 	dsl_dir_t *dd;
-	char *cp;
 	int error;
 
 	error = dsl_pool_hold(fsname, FTAG, &dp);
@@ -5576,6 +5583,395 @@ LIBZFS_CORE_WRAPPER_FUNC(get_holds)
 LIBZFS_CORE_WRAPPER_FUNC(rollback)
 LIBZFS_CORE_WRAPPER_FUNC(bookmark)
 LIBZFS_CORE_WRAPPER_FUNC(destroy_bookmarks)
+
+#define	DLS_TRAVERSE_ALL	(DLS_TRAVERSE_FILESYSTEM | \
+				DLS_TRAVERSE_SNAPSHOT | \
+				DLS_TRAVERSE_VOLUME | \
+				DLS_TRAVERSE_BOOKMARK)
+
+typedef enum dls_flag {
+	DLS_RECURSE		= 1 << 0,
+	DLS_TRAVERSE_FILESYSTEM	= 1 << 1,
+	DLS_TRAVERSE_SNAPSHOT	= 1 << 2,
+	DLS_TRAVERSE_VOLUME	= 1 << 3,
+	DLS_TRAVERSE_BOOKMARK	= 1 << 4,
+} dls_flag_t;
+
+typedef struct dls {
+	int dls_fd;
+	struct task_struct *dls_task;
+	uf_info_t *dls_fip;
+	vnode_t *dls_vp;
+	dmu_oslnode_t *dls_tree;
+	uint64_t dls_depth;
+	dls_flag_t dls_flags;
+	const char *dls_fsname;
+} dls_t;
+
+static int
+dump_zpr(nvlist_t *nvl, vnode_t *vp) {
+	size_t nvsize;
+	ssize_t resid;
+	char *packed;
+	zfs_pipe_record_t *zpr;
+	int err;
+
+	ASSERT(sizeof (zfs_pipe_record_t) == sizeof (uint64_t));
+
+	nvsize = fnvlist_size(nvl);
+	if (nvsize > (1 << (sizeof (zpr->zpr_data_size) + 8)))
+		return (EOVERFLOW);
+
+	/*
+	 * Allocate memory ourselves so that we can include space for the
+	 * header.
+	 */
+	zpr = kmem_alloc(nvsize + sizeof (zfs_pipe_record_t), KM_SLEEP);
+
+	/* Setup header */
+	bzero(zpr, sizeof (zfs_pipe_record_t));
+	zpr->zpr_data_size = (uint32_t) nvsize;
+#ifdef  _LITTLE_ENDIAN
+	zpr->zpr_endian = 1;
+#endif
+
+	packed = (char *)(zpr + 1);
+	err = nvlist_pack(nvl, &packed, &nvsize, NV_ENCODE_XDR, 0);
+
+	if (err)
+		goto out;
+
+	err = vn_rdwr(UIO_WRITE, vp, (caddr_t) zpr, nvsize +
+	    sizeof (zfs_pipe_record_t), 0, UIO_SYSSPACE, FAPPEND,
+	    RLIM64_INFINITY, CRED(), &resid);
+
+out:
+	kmem_free(zpr, nvsize + sizeof (zfs_pipe_record_t));
+
+	return (err);
+}
+
+#define	STRLEN(s) (sizeof (s)/sizeof (s[0]) - 1)
+
+static int
+dump_fs(vnode_t *vp, const char *fsname, nvlist_t *nvprops, dmu_objset_stats_t
+	*objset_stats) {
+	int err;
+	nvlist_t *outnvl = fnvlist_alloc();
+
+	fnvlist_add_string(outnvl, "name", fsname);
+
+	if (!nvlist_empty(nvprops))
+		fnvlist_add_nvlist(outnvl, "properties", nvprops);
+
+	if (objset_stats != NULL) {
+		nvlist_t *nvl = dmu_objset_stats_nvlist(objset_stats);
+		fnvlist_add_nvlist(outnvl, "dmu_objset_stats", nvl);
+		fnvlist_free(nvl);
+	}
+
+	err = dump_zpr(outnvl, vp);
+	fnvlist_free(outnvl);
+	return (err);
+}
+
+static int
+dump_osltree_impl(dsl_dataset_t *ds, dls_t *dls, uint64_t depth)
+{
+	static const size_t fsname_len = MAXNAMELEN + STRLEN(MOS_DIR_NAME) + 1;
+	dsl_pool_t *dp;
+	nvlist_t *nvl;
+	objset_t *osp;
+	char *fsname;
+	dmu_objset_stats_t objset_stats;
+	boolean_t issnap;
+	int err;
+
+	dp = ds->ds_dir->dd_pool;
+	dsl_pool_config_enter(dp, FTAG);
+	dmu_objset_from_ds(ds, &osp);
+	err = zfs_ioc_objset_stats_impl(&nvl,
+	    &objset_stats, osp, B_TRUE);
+	dsl_pool_config_exit(dp, FTAG);
+	if (err)
+		return (err);
+
+	fsname = kmem_alloc(fsname_len, KM_SLEEP);
+	dmu_objset_name(osp, fsname);
+
+	/* Restrict access to hidden datasets from zones */
+	if (dataset_name_hidden(fsname)) {
+		fnvlist_free(nvl);
+		kmem_free(fsname, fsname_len);
+		return (0);
+	}
+
+	issnap = (strchr(fsname, '@') != NULL);
+
+	err = dump_fs(dls->dls_vp, fsname, nvl, &objset_stats);
+	fnvlist_free(nvl);
+
+	if ((err == 0) && !issnap && dls->dls_depth <= 1 + depth &&
+	    (dls->dls_flags & DLS_TRAVERSE_BOOKMARK)) {
+		nvlist_t *innvl = fnvlist_alloc();
+		nvlist_t *outnvl = fnvlist_alloc();
+		boolean_t one = (dls->dls_fsname &&
+		    strchr(dls->dls_fsname, '#') != NULL);
+
+		fnvlist_add_boolean(innvl, zfs_prop_to_name(ZFS_PROP_GUID));
+		fnvlist_add_boolean(innvl,
+		    zfs_prop_to_name(ZFS_PROP_CREATETXG));
+		fnvlist_add_boolean(innvl,
+		    zfs_prop_to_name(ZFS_PROP_CREATION));
+
+		if (dsl_get_bookmarks_impl(ds, innvl, outnvl) == 0) {
+			nvpair_t *pair;
+			for (pair = nvlist_next_nvpair(outnvl, NULL);
+			    pair != NULL;
+			    pair = nvlist_next_nvpair(outnvl, pair)) {
+				nvlist_t *nvl = NULL;
+				char *bname = kmem_asprintf("%s#%s", fsname,
+				    nvpair_name(pair));
+				VERIFY0(nvpair_value_nvlist(pair, &nvl));
+
+				if (one &&
+				    strcmp(dls->dls_fsname, bname) == 0) {
+					strfree(bname);
+					continue;
+				}
+
+				err = dump_fs(dls->dls_vp, bname, nvl,
+				    &objset_stats);
+				strfree(bname);
+				if (err || one)
+					break;
+
+			}
+
+		}
+		fnvlist_free(innvl);
+		fnvlist_free(outnvl);
+	}
+
+	kmem_free(fsname, fsname_len);
+
+	return (err);
+}
+
+static void
+dump_osltree(dmu_oslnode_t *parent, uint64_t depth, dls_t *dls)
+{
+	dmu_oslnode_t *child;
+	list_t *list;
+	dsl_dataset_t *ds = parent->dol_ds;
+
+	if (ds)
+		dump_osltree_impl(ds, dls, depth);
+
+	list = &parent->dol_child;
+	for (child = list_head(list); child != NULL;
+	    child = list_next(list, child)) {
+
+		dump_osltree(child, depth + 1, dls);
+	}
+
+}
+
+static void
+dump_list_strategy(void *arg)
+{
+	dls_t *dls = arg;
+	zfs_pipe_record_t zpr;
+	ssize_t resid;
+
+	dump_osltree(dls->dls_tree, 0, dls);
+
+	bzero(&zpr, sizeof (zfs_pipe_record_t));
+	(void) vn_rdwr(UIO_WRITE, dls->dls_vp, (caddr_t) &zpr,
+	    sizeof (uint64_t), 0, UIO_SYSSPACE, FAPPEND, RLIM64_INFINITY,
+	    CRED(), &resid);
+
+	areleasef(dls->dls_fd, dls->dls_fip);
+	dmu_objset_freelist(dls->dls_tree);
+	kmem_free(dls->dls_fsname, sizeof (dls_t));
+	kmem_free(dls, sizeof (dls_t));
+}
+
+static int
+zfs_stable_ioc_zfs_list(const char *fsname, nvlist_t *innvl,
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	dsl_pool_t *dp = NULL;
+	int fd;
+	file_t *fp;
+	nvlist_t *type = NULL;
+	dls_t *dls;
+	dmu_oslnode_t *tree = NULL;
+	dls_flag_t dls_flags = 0;
+	uint64_t depth = ~0;
+	uint64_t ddobj;
+	int error;
+
+	error = nvlist_lookup_int32(innvl, "fd", &fd);
+	if (error != 0)
+		return (SET_ERROR(EINVAL));
+
+	fp = getf(fd);
+	if (fp == NULL) {
+		return (SET_ERROR(EBADF));
+	}
+
+	if (nvlist_lookup_nvlist(opts, "type", &type) == 0 &&
+	    !nvlist_empty(type)) {
+		if (nvlist_exists(type, "all"))
+			dls_flags |= DLS_TRAVERSE_ALL;
+		else {
+			if (nvlist_exists(type, "bookmark"))
+				dls_flags |= DLS_TRAVERSE_BOOKMARK;
+			if (nvlist_exists(type, "filesystem"))
+				dls_flags |= DLS_TRAVERSE_FILESYSTEM;
+			if (nvlist_exists(type, "snap"))
+				dls_flags |= DLS_TRAVERSE_SNAPSHOT;
+			if (nvlist_exists(type, "snapshot"))
+				dls_flags |= DLS_TRAVERSE_SNAPSHOT;
+			if (nvlist_exists(type, "volume"))
+				dls_flags |= DLS_TRAVERSE_VOLUME;
+		}
+	} else {
+		dls_flags |= DLS_TRAVERSE_FILESYSTEM;
+		dls_flags |= DLS_TRAVERSE_VOLUME;
+	}
+
+	/* Pass an object number when given a DSL directory name */
+	if (fsname != NULL && fsname[0] != '\0') {
+		spa_t *spa;
+		dsl_dataset_t *ds = NULL;
+		int dmu_flags;
+
+		if (nvlist_exists(opts, "recurse")) {
+			dls_flags |= DLS_RECURSE;
+			(void) nvlist_lookup_uint64(opts, "recurse", &depth);
+		} else {
+			depth = 0;
+		}
+		mutex_enter(&spa_namespace_lock);
+
+		spa = spa_lookup(fsname);
+		if (spa == NULL) {
+			mutex_exit(&spa_namespace_lock);
+			return (ENOENT);
+		}
+
+		dp = spa_get_dsl(spa);
+
+		dsl_pool_config_enter(dp, FTAG);
+		mutex_exit(&spa_namespace_lock);
+
+		error = dsl_dataset_hold(dp, fsname, FTAG, &ds);
+
+		/* Adopt sane defaults based on the DSL directory */
+		if (nvlist_empty(type)) {
+			if ((strchr(fsname, '#') != NULL)) {
+				dls_flags |= DLS_TRAVERSE_BOOKMARK;
+				dls_flags &= ~DLS_RECURSE;
+			} else if ((strchr(fsname, '@') != NULL)) {
+				dls_flags |= DLS_TRAVERSE_SNAPSHOT;
+				dls_flags &= ~DLS_RECURSE;
+			} else {
+				objset_t *osp;
+				dmu_objset_from_ds(ds, &osp);
+
+				switch (dmu_objset_type(osp)) {
+				case DMU_OST_ZVOL:
+					dls_flags |= DLS_TRAVERSE_VOLUME;
+					break;
+				case DMU_OST_ZFS:
+					dls_flags |= DLS_TRAVERSE_FILESYSTEM;
+					break;
+				default:
+					VERIFY(0);
+				}
+			}
+		}
+
+		dmu_flags = (dls_flags & DLS_RECURSE) ?
+			DS_FIND_CHILDREN : 0;
+		if (dls_flags & DLS_TRAVERSE_SNAPSHOT)
+			dmu_flags |= DS_FIND_SNAPSHOTS;
+
+		ddobj = ds->ds_dir->dd_object;
+		dsl_dataset_rele(ds, FTAG);
+
+		/* XXX: Do we want to ignore this error? */
+		if (error == 0)
+			(void) dmu_objset_getlist(dp, ddobj, dmu_flags, &tree,
+			    depth);
+
+		dsl_pool_config_exit(dp, FTAG);
+		if (error)
+			return (error);
+	} else {
+		spa_t *spa;
+		dsl_pool_t *dp;
+
+		tree = dmu_oslnode_alloc(NULL, NULL);
+
+		mutex_enter(&spa_namespace_lock);
+		for (spa = spa_next(NULL); spa != NULL; spa = spa_next(spa)) {
+			uint64_t listsnap = 0;
+			int dmu_flags = DS_FIND_CHILDREN;
+			if (spa_state(spa) != POOL_STATE_ACTIVE)
+				continue;
+			dp = spa_get_dsl(spa);
+			dsl_pool_config_enter(dp, FTAG);
+			ddobj = dp->dp_root_dir_obj;
+
+			if (nvlist_empty(type)) {
+				if (spa->spa_pool_props_object != 0) {
+					(void) zap_lookup(dp->dp_meta_objset,
+					    spa->spa_pool_props_object,
+					    zpool_prop_to_name
+					    (ZPOOL_PROP_LISTSNAPS),
+					    sizeof (uint64_t), 1, &listsnap);
+				}
+
+				if (listsnap != 0) {
+					dmu_flags |= DS_FIND_SNAPSHOTS;
+				}
+
+			} else {
+				if (dls_flags & DLS_TRAVERSE_SNAPSHOT)
+					dmu_flags |= DS_FIND_SNAPSHOTS;
+			}
+
+			(void) dmu_objset_getlist(dp, ddobj, dmu_flags, &tree,
+			    depth);
+
+			dsl_pool_config_exit(dp, FTAG);
+
+		}
+		mutex_exit(&spa_namespace_lock);
+
+	}
+
+	dls = kmem_alloc(sizeof (dls_t), KM_SLEEP);
+	dls->dls_fd = fd;
+	dls->dls_tree = tree;
+	dls->dls_fip = P_FINFO(curproc);
+	dls->dls_vp = fp->f_vnode;
+	dls->dls_depth = depth;
+	dls->dls_flags = dls_flags;
+	dls->dls_fsname = (fsname != NULL && fsname[0] != '\0') ?
+	    strdup(fsname) : NULL;
+
+	if (!taskq_dispatch(system_taskq, dump_list_strategy, dls, TQ_SLEEP)) {
+		kmem_free(dls, sizeof (dls_t));
+		releasef(fd);
+		return (SET_ERROR(ENOMEM));
+	}
+
+	return (error);
+}
 
 /*
  * ioctl table for stable interface.
@@ -5719,6 +6115,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_smush_outnvlist	= B_TRUE,
 	.zvec_allow_log		= B_TRUE,
 },
+{	.zvec_name		= "zfs_list",
+	.zvec_func		= zfs_stable_ioc_zfs_list,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME_OR_EMPTY,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_TRUE,
+},
 };
 
 static const ssize_t zfs_stable_ioc_vec_count =
@@ -5731,20 +6135,28 @@ zfs_namecheck(const char *name, zfs_ioc_namecheck_t namecheck,
 	int error = 0;
 
 	switch (namecheck) {
+	case POOL_NAME_OR_EMPTY:
+		if (name[0] == '\0')
+			break;
 	case POOL_NAME:
 		if (pool_namecheck(name, NULL, NULL) != 0)
 			error = SET_ERROR(EINVAL);
 		else
 			error = pool_status_check(name,
-			    namecheck, pool_check);
+			    POOL_NAME, pool_check);
 		break;
 
+	case DATASET_NAME_OR_EMPTY:
+		if (name[0] == '\0')
+			break;
 	case DATASET_NAME:
+		if (name[0] == '\0')
+			break;
 		if (dataset_namecheck(name, NULL, NULL) != 0)
 			error = SET_ERROR(EINVAL);
 		else
 			error = pool_status_check(name,
-			    namecheck, pool_check);
+			    DATASET_NAME, pool_check);
 		break;
 
 	case NO_NAME:
@@ -5821,7 +6233,6 @@ zfs_ioc_stable(zfs_cmd_t *zc)
 
 	for (i = 0; i < zfs_stable_ioc_vec_count; i++) {
 		if (strcmp(zfs_stable_ioc_vec[i].zvec_name, cmd) == 0) {
-			nvlist_t *lognv = NULL;
 			const zfs_stable_ioc_vec_t *vec =
 			    &zfs_stable_ioc_vec[i];
 			nvlist_t *lognv = NULL;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5518,6 +5518,33 @@ zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 	return (error);
 }
 
+static int
+zfs_stable_ioc_set_props(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
+    nvlist_t *opts, uint64_t version)
+{
+	zprop_source_t source;
+	boolean_t received;
+	int error = 0;
+
+	received = nvlist_exists(opts, "received");
+	source = (received ? ZPROP_SRC_RECEIVED : ZPROP_SRC_LOCAL);
+	if (received) {
+		nvlist_t *origprops;
+
+		if (dsl_prop_get_received(fsname, &origprops) == 0) {
+			(void) clear_received_props(fsname, origprops, innvl);
+			nvlist_free(origprops);
+		}
+
+		error = dsl_prop_set_hasrecvd(fsname);
+	}
+
+	if (error == 0)
+		error = zfs_set_prop_nvlist(fsname, source, innvl, outnvl);
+
+	return (error);
+}
+
 int
 pool_status_check(const char *name, zfs_ioc_namecheck_t type,
     zfs_ioc_poolcheck_t check);
@@ -5623,6 +5650,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_namecheck		= DATASET_NAME,
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_set_props",
+	.zvec_func		= zfs_stable_ioc_set_props,
+	.zvec_secpolicy		= zfs_secpolicy_config,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_TRUE,
 	.zvec_allow_log		= B_TRUE,
 },
 {	.zvec_name		= "zfs_destroy_snaps",

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1332,7 +1332,7 @@ get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 	if ((error = ddi_copyin((void *)(uintptr_t)nvl, packed, size,
 	    iflag)) != 0) {
 		vmem_free(packed, size);
-		return (error);
+		return (EFAULT);
 	}
 
 	if ((error = nvlist_unpack(packed, size, &list, 0)) != 0) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5649,16 +5649,16 @@ zfs_ioc_stable(zfs_cmd_t *zc)
 			goto out;
 	}
 
-	if ((error = nvlist_lookup_string(mnvl, "cmd", &cmd)))
+	if ((error = nvlist_lookup_string(mnvl, "cmd", &cmd)) != 0)
 		return (error);
 
-	if ((error = nvlist_lookup_nvlist(mnvl, "innvl", &innvl)))
+	if ((error = nvlist_lookup_nvlist(mnvl, "innvl", &innvl)) != 0)
 		return (error);
 
-	if (nvlist_lookup_nvlist(mnvl, "opts", &opts))
+	if (nvlist_lookup_nvlist(mnvl, "opts", &opts) != 0)
 		opts = NULL;
 
-	if ((error = nvlist_lookup_uint64(mnvl, "version", &version)))
+	if ((error = nvlist_lookup_uint64(mnvl, "version", &version)) != 0)
 		return (error);
 
 	/* We do not support sequence numbers above 0 right now */

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5522,13 +5522,11 @@ static int
 zfs_stable_ioc_set_props(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
     nvlist_t *opts, uint64_t version)
 {
-	zprop_source_t source;
-	boolean_t received;
+	zprop_source_t source = ZPROP_SRC_LOCAL;
 	int error = 0;
 
-	received = nvlist_exists(opts, "received");
-	source = (received ? ZPROP_SRC_RECEIVED : ZPROP_SRC_LOCAL);
-	if (received) {
+	if (nvlist_exists(opts, "received")) {
+		source = ZPROP_SRC_RECEIVED;
 		nvlist_t *origprops;
 
 		if (dsl_prop_get_received(fsname, &origprops) == 0) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3814,6 +3814,39 @@ zfs_ioc_destroy_bookmarks(const char *poolname, nvlist_t *innvl,
 	return (error);
 }
 
+
+/* If ostype is DMU_OST_NONE, we perform a lookup. */
+static int
+zfs_destroy_impl(const char *fsname, dmu_objset_type_t ostype,
+	boolean_t defer_destroy)
+{
+	int err;
+
+	if (ostype == DMU_OST_NONE) {
+		objset_t *os;
+
+		err = dmu_objset_hold(fsname, FTAG, &os);
+		if (err != 0)
+			return (err);
+		ostype = dmu_objset_type(os);
+		dmu_objset_rele(os, FTAG);
+	}
+
+	if (ostype == DMU_OST_ZFS) {
+		err = zfs_unmount_snap(fsname);
+		if (err != 0)
+			return (err);
+	}
+
+	if (strchr(fsname, '@'))
+		err = dsl_destroy_snapshot(fsname, defer_destroy);
+	else
+		err = dsl_destroy_head(fsname);
+	if (ostype == DMU_OST_ZVOL && err == 0)
+		(void) zvol_remove_minor(fsname);
+	return (err);
+}
+
 /*
  * inputs:
  * zc_name		name of dataset to destroy
@@ -3825,21 +3858,8 @@ zfs_ioc_destroy_bookmarks(const char *poolname, nvlist_t *innvl,
 static int
 zfs_ioc_destroy(zfs_cmd_t *zc)
 {
-	int err;
-
-	if (zc->zc_objset_type == DMU_OST_ZFS) {
-		err = zfs_unmount_snap(zc->zc_name);
-		if (err != 0)
-			return (err);
-	}
-
-	if (strchr(zc->zc_name, '@'))
-		err = dsl_destroy_snapshot(zc->zc_name, zc->zc_defer_destroy);
-	else
-		err = dsl_destroy_head(zc->zc_name);
-	if (zc->zc_objset_type == DMU_OST_ZVOL && err == 0)
-		(void) zvol_remove_minor(zc->zc_name);
-	return (err);
+	return (zfs_destroy_impl(zc->zc_name, zc->zc_objset_type,
+	    zc->zc_defer_destroy));
 }
 
 /*
@@ -6081,6 +6101,14 @@ zfs_stable_ioc_zfs_list(const char *fsname, nvlist_t *innvl,
 	return (error);
 }
 
+static int
+zfs_stable_ioc_zfs_destroy(const char *fsname, nvlist_t *innvl,
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	return (zfs_destroy_impl(fsname, DMU_OST_NONE,
+	    nvlist_exists(opts, "defer")));
+}
+
 /*
  * ioctl table for stable interface.
  * Functions use zfs_/zpool_ prefixes to distinguish between their uses
@@ -6242,6 +6270,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 {	.zvec_name		= "zfs_inherit",
 	.zvec_func		= zfs_stable_ioc_zfs_inherit,
 	.zvec_secpolicy		= zfs_secpolicy_inherit_prop,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_TRUE,
+},
+{	.zvec_name		= "zfs_destroy",
+	.zvec_func		= zfs_stable_ioc_zfs_destroy,
+	.zvec_secpolicy		= zfs_secpolicy_destroy,
 	.zvec_namecheck		= DATASET_NAME,
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_FALSE,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2790,7 +2790,7 @@ retry:
 	}
 
 	if (!nvlist_empty(genericnvl) &&
-	    (rv = dsl_props_set(dsname, source, genericnvl)) != 0 &&
+	    dsl_props_set(dsname, source, genericnvl) != 0 &&
 	    atomic == B_FALSE) {
 		/*
 		 * If this fails, we still want to set as many properties as we

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6393,8 +6393,8 @@ zfs_ioc_stable(zfs_cmd_t *zc)
 	if ((error = nvlist_lookup_string(mnvl, "cmd", &cmd)) != 0)
 		return (error);
 
-	if ((error = nvlist_lookup_nvlist(mnvl, "innvl", &innvl)) != 0)
-		return (error);
+	if (nvlist_lookup_nvlist(mnvl, "innvl", &innvl) != 0)
+		innvl = NULL;
 
 	if (nvlist_lookup_nvlist(mnvl, "opts", &opts) != 0)
 		opts = NULL;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6027,14 +6027,12 @@ zfs_stable_ioc_zfs_list(const char *fsname, nvlist_t *innvl,
 		if (dls_flags & DLS_TRAVERSE_SNAPSHOT)
 			dmu_flags |= DS_FIND_SNAPSHOTS;
 
-		ddobj = ds->ds_dir->dd_object;
-		dsl_dataset_rele(ds, FTAG);
-
-		/* XXX: Do we want to ignore this error? */
-		if (error == 0)
+		if (error == 0) {
+			ddobj = ds->ds_dir->dd_object;
+			dsl_dataset_rele(ds, FTAG);
 			(void) dmu_objset_getlist(dp, ddobj, dmu_flags, &tree,
 			    depth);
-
+		}
 		dsl_pool_config_exit(dp, FTAG);
 		if (error)
 			return (error);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5421,6 +5421,56 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 }
 
 static int
+zfs_stable_ioc_send_progress(const char *snapname, nvlist_t *innvl,
+     nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	dsl_pool_t *dp;
+	dsl_dataset_t *ds;
+	dmu_sendarg_t *dsp = NULL;
+	int error;
+	int fd;
+
+	error = nvlist_lookup_int32(innvl, "fd", &fd);
+	if (error != 0)
+		return (SET_ERROR(EINVAL));
+
+	error = dsl_pool_hold(snapname, FTAG, &dp);
+	if (error != 0)
+		return (error);
+
+	error = dsl_dataset_hold(dp, snapname, FTAG, &ds);
+	if (error != 0) {
+		dsl_pool_rele(dp, FTAG);
+		return (error);
+	}
+
+	mutex_enter(&ds->ds_sendstream_lock);
+
+	/*
+	 * Iterate over all the send streams currently active on this dataset.
+	 * If there's one which matches the specified file descriptor _and_ the
+	 * stream was started by the current process, return the progress of
+	 * that stream.
+	 */
+	for (dsp = list_head(&ds->ds_sendstreams); dsp != NULL;
+	    dsp = list_next(&ds->ds_sendstreams, dsp)) {
+		if (dsp->dsa_outfd == fd &&
+		    dsp->dsa_proc->group_leader == curproc->group_leader)
+			break;
+	}
+
+	if (dsp != NULL)
+		fnvlist_add_uint64(outnvl, "offset", *(dsp->dsa_off));
+	else
+		error = SET_ERROR(ENOENT);
+
+	mutex_exit(&ds->ds_sendstream_lock);
+	dsl_dataset_rele(ds, FTAG);
+	dsl_pool_rele(dp, FTAG);
+	return (error);
+}
+
+static int
 zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
     nvlist_t *opts, uint64_t version)
 {
@@ -5537,6 +5587,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 },
 {	.zvec_name		= "zfs_send_space",
 	.zvec_func		= zfs_stable_ioc_zfs_send_space,
+	.zvec_secpolicy		= zfs_secpolicy_read,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_FALSE,
+},
+{	.zvec_name		= "zfs_send_progress",
+	.zvec_func		= zfs_stable_ioc_send_progress,
 	.zvec_secpolicy		= zfs_secpolicy_read,
 	.zvec_namecheck		= DATASET_NAME,
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5103,14 +5103,32 @@ zfs_ioc_space_written(zfs_cmd_t *zc)
 static int
 zfs_ioc_space_snaps(const char *lastsnap, nvlist_t *innvl, nvlist_t *outnvl)
 {
-	int error;
+	int error, len;
 	dsl_pool_t *dp;
 	dsl_dataset_t *new, *old;
-	char *firstsnap;
+	char *firstsnap, *sp;
 	uint64_t used, comp, uncomp;
 
 	if (nvlist_lookup_string(innvl, "firstsnap", &firstsnap) != 0)
 		return (SET_ERROR(EINVAL));
+
+	sp = strpbrk(firstsnap, "@#");
+	if (sp == NULL)
+		return (SET_ERROR(EINVAL));
+	if (*sp == '#')
+		return (SET_ERROR(EINVAL));
+	len = sp - firstsnap;
+
+	sp = strpbrk(lastsnap, "@#");
+	if (sp == NULL)
+		return (SET_ERROR(EINVAL));
+	if (*sp == '#')
+		return (SET_ERROR(EINVAL));
+
+	if (len != sp - firstsnap)
+		return (SET_ERROR(EXDEV));
+	if (strncmp(lastsnap, firstsnap, len) != 0)
+		return (SET_ERROR(EXDEV));
 
 	error = dsl_pool_hold(lastsnap, FTAG, &dp);
 	if (error != 0)

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5441,7 +5441,6 @@ LIBZFS_CORE_WRAPPER_FUNC(release)
 LIBZFS_CORE_WRAPPER_FUNC(get_holds)
 LIBZFS_CORE_WRAPPER_FUNC(rollback)
 LIBZFS_CORE_WRAPPER_FUNC(bookmark)
-LIBZFS_CORE_WRAPPER_FUNC(get_bookmarks)
 LIBZFS_CORE_WRAPPER_FUNC(destroy_bookmarks)
 
 /*
@@ -5553,14 +5552,6 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_TRUE,
 	.zvec_allow_log		= B_TRUE,
-},
-{	.zvec_name		= "zfs_get_bookmarks",
-	.zvec_func		= zfs_stable_ioc_zfs_get_bookmarks,
-	.zvec_secpolicy		= zfs_secpolicy_read,
-	.zvec_namecheck		= DATASET_NAME,
-	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
-	.zvec_smush_outnvlist	= B_FALSE,
-	.zvec_allow_log		= B_FALSE,
 },
 {	.zvec_name		= "zfs_destroy_bookmarks",
 	.zvec_func		= zfs_stable_ioc_zfs_destroy_bookmarks,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5340,6 +5340,7 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	int fd;
 	file_t *fp;
 	boolean_t embedok;
+	boolean_t fromorigin;
 
 	error = nvlist_lookup_int32(innvl, "fd", &fd);
 	if (error != 0)
@@ -5348,12 +5349,17 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	(void) nvlist_lookup_string(innvl, "fromsnap", &fromname);
 
 	embedok = nvlist_exists(innvl, "embedok");
+	fromorigin = nvlist_exists(innvl, "fromorigin");
+
+	if (fromname != NULL && fromorigin)
+		return (SET_ERROR(EINVAL));
 
 	if ((fp = getf(fd)) == NULL)
 		return (SET_ERROR(EBADF));
 
 	off = fp->f_offset;
-	error = dmu_send(snapname, fromname, embedok, fd, fp->f_vnode, &off);
+	error = dmu_send(snapname, fromname, embedok, fromorigin,
+	    fd, fp->f_vnode, &off);
 
 	if (VOP_SEEK(fp->f_vnode, fp->f_offset, &off, NULL) == 0)
 		fp->f_offset = off;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5812,7 +5812,7 @@ zfs_stable_ioc_zfs_list(const char *fsname, nvlist_t *innvl,
 	uint64_t ddobj;
 	int error;
 
-	error = nvlist_lookup_int32(innvl, "fd", &fd);
+	error = nvlist_lookup_int32(opts, "fd", &fd);
 	if (error != 0)
 		return (SET_ERROR(EINVAL));
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1225,22 +1225,43 @@ zfs_secpolicy_inject(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts, cred_t *cr)
 
 /* ARGSUSED */
 static int
-zfs_secpolicy_inherit_prop(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+zfs_secpolicy_inherit_prop_impl(const char *fsname, const char *propname,
     cred_t *cr)
 {
-	zfs_prop_t prop = zfs_name_to_prop(zc->zc_value);
+	zfs_prop_t prop = zfs_name_to_prop(propname);
 
 	if (prop == ZPROP_INVAL) {
-		if (!zfs_prop_user(zc->zc_value))
+		if (!zfs_prop_user(propname))
 			return (SET_ERROR(EINVAL));
-		return (zfs_secpolicy_write_perms(zc->zc_name,
+		return (zfs_secpolicy_write_perms(fsname,
 		    ZFS_DELEG_PERM_USERPROP, cr));
 	} else {
-		return (zfs_secpolicy_setprop(zc->zc_name, prop,
+		return (zfs_secpolicy_setprop(fsname, prop,
 		    NULL, cr));
 	}
 }
+/* ARGSUSED */
+static int
+zfs_secpolicy_inherit_prop(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
+    cred_t *cr)
+{
+	char *propname;
+	int error;
 
+	if ((error = nvlist_lookup_string(innvl, "prop", &propname)))
+		return (error);
+
+	return (zfs_secpolicy_inherit_prop_impl(zc->zc_name, propname, cr));
+}
+
+/* ARGSUSED */
+static int
+zfs_secpolicy_inherit_prop_legacy(zfs_cmd_t *zc, nvlist_t *innvl,
+    nvlist_t *opts, cred_t *cr)
+{
+	return (zfs_secpolicy_inherit_prop_impl(zc->zc_name, zc->zc_value,
+	    cr));
+}
 static int
 zfs_secpolicy_userspace_one(zfs_cmd_t *zc, nvlist_t *innvl, nvlist_t *opts,
     cred_t *cr)
@@ -2929,20 +2950,10 @@ zfs_ioc_set_prop(zfs_cmd_t *zc)
 	return (error);
 }
 
-/*
- * inputs:
- * zc_name		name of filesystem
- * zc_value		name of property to inherit
- * zc_cookie		revert to received value if TRUE
- *
- * outputs:		none
- */
 static int
-zfs_ioc_inherit_prop(zfs_cmd_t *zc)
+zfs_inherit_prop(const char *fsname, const char *propname, boolean_t received)
 {
-	const char *propname = zc->zc_value;
 	zfs_prop_t prop = zfs_name_to_prop(propname);
-	boolean_t received = zc->zc_cookie;
 	zprop_source_t source = (received
 	    ? ZPROP_SRC_NONE		/* revert to received value, if any */
 	    : ZPROP_SRC_INHERITED);	/* explicitly inherit */
@@ -2985,7 +2996,7 @@ zfs_ioc_inherit_prop(zfs_cmd_t *zc)
 		}
 
 		pair = nvlist_next_nvpair(dummy, NULL);
-		err = zfs_prop_set_special(zc->zc_name, source, pair);
+		err = zfs_prop_set_special(fsname, source, pair);
 		nvlist_free(dummy);
 		if (err != -1)
 			return (err); /* special property already handled */
@@ -3001,7 +3012,22 @@ zfs_ioc_inherit_prop(zfs_cmd_t *zc)
 	}
 
 	/* property name has been validated by zfs_secpolicy_inherit_prop() */
-	return (dsl_prop_inherit(zc->zc_name, zc->zc_value, source));
+	return (dsl_prop_inherit(fsname, propname, source));
+}
+
+/*
+ * inputs:
+ * zc_name		name of filesystem
+ * zc_value		name of property to inherit
+ * zc_cookie		revert to received value if TRUE
+ *
+ * outputs:		none
+ */
+static int
+zfs_ioc_inherit_prop(zfs_cmd_t *zc)
+{
+	return (zfs_inherit_prop(zc->zc_name, zc->zc_value,
+	    !!(zc->zc_cookie)));
 }
 
 static int
@@ -4099,8 +4125,8 @@ zfs_check_clearable(char *dataset, nvlist_t *props, nvlist_t **errlist)
 
 		(void) strcpy(zc->zc_value, nvpair_name(pair));
 		if ((err = zfs_check_settable(dataset, pair, CRED())) != 0 ||
-		    (err = zfs_secpolicy_inherit_prop(zc, NULL, NULL, CRED()))
-		    != 0) {
+		    (err = zfs_secpolicy_inherit_prop_legacy(zc, NULL, NULL,
+		    CRED())) != 0) {
 			VERIFY(nvlist_remove_nvpair(props, pair) == 0);
 			VERIFY(nvlist_add_int32(errors,
 			    zc->zc_value, err) == 0);
@@ -5598,6 +5624,24 @@ zfs_stable_ioc_set_props(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 	return (error);
 }
 
+
+/*
+ * XXX: Before we stabilize this, we should consider making it accept a list of
+ * things to inherit
+ */
+static int
+zfs_stable_ioc_zfs_inherit(const char *fsname, nvlist_t *innvl,
+    nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
+{
+	char *propname;
+	int error;
+
+	if ((error = nvlist_lookup_string(innvl, "prop", &propname)))
+		return (error);
+
+	return (zfs_inherit_prop(fsname, propname,
+	    nvlist_exists(opts, "received")));
+}
 static int
 zfs_stable_ioc_zfs_rename(const char *oldname, nvlist_t *innvl,
     nvlist_t *outnvl, nvlist_t *opts, uint64_t version)
@@ -6195,6 +6239,14 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_smush_outnvlist	= B_TRUE,
 	.zvec_allow_log		= B_TRUE,
 },
+{	.zvec_name		= "zfs_inherit",
+	.zvec_func		= zfs_stable_ioc_zfs_inherit,
+	.zvec_secpolicy		= zfs_secpolicy_inherit_prop,
+	.zvec_namecheck		= DATASET_NAME,
+	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
+	.zvec_smush_outnvlist	= B_FALSE,
+	.zvec_allow_log		= B_TRUE,
+},
 };
 
 static const ssize_t zfs_stable_ioc_vec_count =
@@ -6660,7 +6712,7 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_PROMOTE, zfs_ioc_promote,
 	    zfs_secpolicy_promote);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_INHERIT_PROP,
-	    zfs_ioc_inherit_prop, zfs_secpolicy_inherit_prop);
+	    zfs_ioc_inherit_prop, zfs_secpolicy_inherit_prop_legacy);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_SET_FSACL, zfs_ioc_set_fsacl,
 	    zfs_secpolicy_set_fsacl);
 

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -253,6 +253,7 @@ exit 0
 %{_bindir}/*
 %{_libexecdir}/%{name}
 %{_mandir}/man1/*
+%{_mandir}/man3/*
 %{_mandir}/man5/*
 %{_mandir}/man8/*
 %{_udevdir}/vdev_id


### PR DESCRIPTION
@ryao please add this commit to `libzfs_core-wip`.
This functionality is required by flocker.
Please see [ZFS-20](https://clusterhq.atlassian.net/browse/ZFS-20) for a few more details.
