### PR TITLE
zfs_ioc_space_snaps: fix a copy-paste error

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5382,7 +5382,7 @@ zfs_ioc_space_snaps(const char *lastsnap, nvlist_t *innvl, nvlist_t *outnvl)
 	if (*sp == '#')
 		return (SET_ERROR(EINVAL));
 
-	if (len != sp - firstsnap)
+	if (len != sp - lastsnap)
 		return (SET_ERROR(EXDEV));
 	if (strncmp(lastsnap, firstsnap, len) != 0)
 		return (SET_ERROR(EXDEV));


### PR DESCRIPTION
The error resulted in the incorrect comparison of the dataset base
names.

https://clusterhq.atlassian.net/browse/ZFS-39
